### PR TITLE
Update setuptools to automatically determine requirements and namespace package dir tree mapping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,8 @@ python -m venv env
 
 2. Install development version of package
 
+NOTE: `pip install -e .` will not work if install entire namespace package. Use the following:
+
 ```bash
 python setup.py develop
 ```

--- a/setup.py
+++ b/setup.py
@@ -135,17 +135,10 @@ def install_subpackages(
 REQUIREMENTS = build_subpackage_requirements()
 SUBPACKAGES = build_subpackage_mapping()
 
-# Normal installation
-class Install(install):
-    def run(self):
-        install_subpackages(SUBPACKAGES, develop_flag=False)
-        super().run()
-
-
 # Development installation
 class Develop(develop):
     def run(self):
-        install_subpackages(SUBPACKAGES, develop_flag=True)
+        install_subpackages(SUBPACKAGES)
         # Install development requirements
         for dev_requirement in DEVELOPMENT_REQUIREMENTS:
             subprocess.check_call(

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from setuptools import setup
 from setuptools.command.develop import develop
 from setuptools.command.install import install
 
+from typing import Dict, List
 from pathlib import Path
 
 # python root namespace package

--- a/setup.py
+++ b/setup.py
@@ -49,9 +49,6 @@ DESCRIPTION = (
 LONG_DESCRIPTION = Path("README.md").read_text()
 LICENSE = Path("LICENSE").read_text()
 
-# Package dependency requirements
-REQUIREMENTS = []
-
 # Development requirements
 DEVELOPMENT_REQUIREMENTS = ["pytest"]
 

--- a/setup.py
+++ b/setup.py
@@ -141,6 +141,9 @@ def install_subpackages(sources: dict, develop_flag: bool = False) -> None:
             raise Exception(error_message) from e
 
 
+REQUIREMENTS = build_subpackage_requirements()
+SUBPACKAGES = build_subpackage_mapping()
+
 # Normal installation
 class Install(install):
     def run(self):

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,9 @@ def build_subpackage_mapping() -> Dict[str, str]:
     return subpackage_mapping
 
 
-def install_subpackages(sources: dict, develop_flag: bool = False) -> None:
+def install_subpackages(
+    sources: dict,
+) -> None:
     """Install all subpackages in a namespace package
 
     Parameters
@@ -115,27 +117,16 @@ def install_subpackages(sources: dict, develop_flag: bool = False) -> None:
     for k, v in sources.items():
         try:
             subpackage_dir = str(ROOT_DIR / v)
-            if develop_flag:
-                subprocess.check_call(
-                    [
-                        sys.executable,
-                        "-m",
-                        "pip",
-                        "install",
-                        "-e",
-                        subpackage_dir,
-                    ]
-                )
-            else:
-                subprocess.check_call(
-                    [
-                        sys.executable,
-                        "-m",
-                        "pip",
-                        "install",
-                        subpackage_dir,
-                    ]
-                )
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "-e",
+                    subpackage_dir,
+                ]
+            )
         except Exception as e:
             error_message = "An error occurred when installing %s" % (k,)
             raise Exception(error_message) from e

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ from pathlib import Path
 # https://medium.com/@jherreras/python-microlibs-5be9461ad979
 
 NAMESPACE_PACKAGE_NAME = "evaluation_tools"
+SRC_ROOT = "python"
 
 # Package author information
 AUTHOR = "Jason Regina"

--- a/setup.py
+++ b/setup.py
@@ -167,5 +167,5 @@ setup(
     install_requires=REQUIREMENTS,
     extras_require={"test": DEVELOPMENT_REQUIREMENTS},
     python_requires=">=3.7",
-    cmdclass={"install": Install, "develop": Develop},
+    cmdclass={"develop": Develop},
 )

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ MAINTAINER = "Austin Raney"
 MAINTAINER_EMAIL = "arthur.raney@noaa.gov"
 
 # Namespace package version
-VERSION = "1.3.5+1"
+VERSION = "1.3.5+2"
 URL = "https://github.com/NOAA-OWP/evaluation_tools"
 
 # Map subpackage namespace to relative location


### PR DESCRIPTION
In the past it was required to manually update `setup.py` with requirements as well as their dir tree mapping (`slug-name: dir-location`). This PR simply changes the way things are handled in setup.py to support a building an overarching namespace package wheel in the future.

## Changes

- Automatically determine requirements and namespace package dir tree mapping

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
