### PR TITLE
Fix 58

### DIFF
--- a/python/metrics/setup.py
+++ b/python/metrics/setup.py
@@ -25,6 +25,7 @@ DESCRIPTION = "Variety of standard model evaluation metrics."
 # Package dependency requirements
 REQUIREMENTS = [
     "pandas",
+    "numpy>=1.20.0"
 ]
 
 setup(

--- a/python/metrics/setup.py
+++ b/python/metrics/setup.py
@@ -13,7 +13,7 @@ SUBPACKAGE_NAME = "metrics"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "1.0.0-alpha.0"
+VERSION = "1.0.0-alpha.1"
 
 # Package author information
 AUTHOR = "Jason Regina"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ MAINTAINER = "Austin Raney"
 MAINTAINER_EMAIL = "arthur.raney@noaa.gov"
 
 # Namespace package version
-VERSION = "2.0.0-alpha.0"
+VERSION = "2.0.0-alpha.1"
 URL = "https://github.com/NOAA-OWP/hydrotools"
 
 # Short sub-package description


### PR DESCRIPTION
closes #58 

`hydrotools.metrics` now requires numpy `1.20.0` or greater.

## Changes

- `hydrotools.metrics` now requires numpy `1.20.0` or greater.

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
