### PR TITLE
_restclient utilities module: add Alias and AliasGroup classes

### DIFF
--- a/docs/hydrotools._restclient._restclient.rst
+++ b/docs/hydrotools._restclient._restclient.rst
@@ -1,0 +1,7 @@
+hydrotools.\_restclient.\_restclient module
+===========================================
+
+.. automodule:: hydrotools._restclient._restclient
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/hydrotools._restclient.rst
+++ b/docs/hydrotools._restclient.rst
@@ -1,8 +1,19 @@
 hydrotools.\_restclient subpackage
-=========================================
+===============================
 
-.. automodule:: hydrotools._restclient._restclient
+Submodules
+----------
+
+.. toctree::
+   :maxdepth: 4
+
+   hydrotools._restclient._restclient
+   hydrotools._restclient.utilities
+
+Module contents
+---------------
+
+.. automodule:: hydrotools._restclient
    :members:
    :undoc-members:
    :show-inheritance:
-

--- a/docs/hydrotools._restclient.utilities.rst
+++ b/docs/hydrotools._restclient.utilities.rst
@@ -1,0 +1,7 @@
+hydrotools.\_restclient.utilities module
+========================================
+
+.. automodule:: hydrotools._restclient.utilities
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/python/_restclient/hydrotools/_restclient/__init__.py
+++ b/python/_restclient/hydrotools/_restclient/__init__.py
@@ -1,1 +1,3 @@
 from ._restclient import RestClient
+from .utilities import Alias
+from . import utilities

--- a/python/_restclient/hydrotools/_restclient/__init__.py
+++ b/python/_restclient/hydrotools/_restclient/__init__.py
@@ -1,3 +1,3 @@
 from ._restclient import RestClient
-from .utilities import Alias
+from .utilities import Alias, AliasGroup
 from . import utilities

--- a/python/_restclient/hydrotools/_restclient/_iterable_nonstring.py
+++ b/python/_restclient/hydrotools/_restclient/_iterable_nonstring.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+from abc import ABCMeta, abstractmethod
+
+__all__ = ["IterableNonStringLike"]
+
+
+class IterableNonStringLike(metaclass=ABCMeta):
+    """Type iterable that is not a subclass of str or bytes. Useful to test if object
+    `isinstance()`.
+
+    Example:
+        x = "a-string"
+        y = list()
+        isinstance(x, IterableNonStringLike) # False
+        isinstance(y, IterableNonStringLike) # True
+    """
+
+    slots = ()
+
+    @abstractmethod
+    def __iter__(self):
+        while False:
+            yield None
+
+    @classmethod
+    def __subclasshook__(cls, C):
+        if cls is IterableNonStringLike:
+            if any(
+                "__iter__" in B.__dict__
+                and not issubclass(B, str)
+                and not issubclass(B, bytes)
+                for B in C.__mro__
+            ):
+                return True
+        return NotImplemented

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -219,9 +219,9 @@ class AliasGroup:
         Returns
         -------
         Union[int, float, str, bytes, bool, Callable, tuple, frozenset, None]
-           alias value if valid value, else None
+           alias value if valid key, value, or Alias instance, else None
         """
-        option = self.option_map.get(value)
+        option = self.option_map.get(key)
 
         if option is None:
             return None
@@ -230,15 +230,20 @@ class AliasGroup:
 
     @property
     def option_groups(self):
+        """ Mapping of Alias keys's to Alias value's """
         return self._option_groups
 
-    def __getitem__(self, value):
-        option = self.get(value)
+    @property
+    def values(self):
+        """ Frozenset of present Alias value's """
+        return self._values
+
+    def __getitem__(self, key):
+        option = self.get(key)
 
         if option is None:
             raise ValueError(
-                "Invalid value %s. Valid values are %s"
-                % (value, self.option_map.keys())
+                f"Invalid value {str(key)}. Valid values are {str(self.option_map.keys())}"
             )
 
         return option

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -234,9 +234,14 @@ class AliasGroup:
         return self._option_groups
 
     @property
-    def values(self):
+    def values(self) -> frozenset:
         """ Frozenset of present Alias value's """
         return self._values
+
+    @property
+    def keys(self) -> set:
+        """ Alias keys """
+        return set(self.option_map.keys())
 
     def __getitem__(self, key):
         option = self.get(key)

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -51,13 +51,24 @@ class Alias:
             self.__dict__["valid_value"] = self.valid_value | self.key.valid_value
             self.__dict__["key"] = self.key.key
 
-    def get(self, value) -> Any:
+    def get(self, value: Hashable) -> Union[Any, None]:
+        """Get key given a valid alias value. If a valid key is not provided, return
+        None.
+
+        Parameters
+        ----------
+        value : Hashable
+            Valid alias value
+
+        Returns
+        -------
+        Union[Any, None]
+           alias key if valid value, else None
+        """
         if value in self:
             return self.key
 
-        raise ValueError(
-            "Invalid value %s. Valid values are %s" % (value, self.valid_value)
-        )
+        return None
 
     def __contains__(self, value) -> bool:
         return value in self.valid_value

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -32,12 +32,12 @@ class Alias:
         result = foo_alias["bar"]()
     """
 
-    key: Any
+    value: Any
     valid_value: Union[Iterable, Hashable]
 
     def __post_init__(self):
-        # Create deep copy so a ref to a mutable key could not change value implicitly
-        self.__dict__["key"] = deepcopy(self.key)
+        # Create deep copy so a ref to a mutable value could not change keys implicitly
+        self.__dict__["value"] = deepcopy(self.value)
 
         # If non- str/bytes collection, frozenset, else frozenset([valid_value])
         self.__dict__["valid_value"] = (
@@ -46,13 +46,13 @@ class Alias:
             else frozenset([self.valid_value])
         )
 
-        if isinstance(self.key, Alias):
-            # Alias is passed as key, use contents to extend into new instance
-            self.__dict__["valid_value"] = self.valid_value | self.key.valid_value
-            self.__dict__["key"] = self.key.key
+        if isinstance(self.value, Alias):
+            # Alias is passed as value, use contents to extend into new instance
+            self.__dict__["valid_value"] = self.valid_value | self.value.valid_value
+            self.__dict__["value"] = self.value.value
 
     def get(self, value: Hashable) -> Union[Any, None]:
-        """Get key given a valid alias value. If a valid key is not provided, return
+        """Get value given a valid alias value. If a valid value is not provided, return
         None.
 
         Parameters
@@ -63,10 +63,10 @@ class Alias:
         Returns
         -------
         Union[Any, None]
-           alias key if valid value, else None
+           alias value if valid value, else None
         """
         if value in self:
-            return self.key
+            return self.value
 
         return None
 
@@ -74,20 +74,20 @@ class Alias:
         return value in self.valid_value
 
     def __getitem__(self, value) -> Any:
-        key = self.get(value)
+        value = self.get(value)
 
-        if key is None:
+        if value is None:
             raise ValueError(
                 "Invalid value %s. Valid values are %s" % (value, self.valid_value)
             )
 
-        return key
+        return value
 
     def __str__(self):
-        return str(self.key)
+        return str(self.value)
 
     def __repr__(self):
-        return f"{str(self.key)}: {str(self.valid_value)}"
+        return f"{str(self.value)}: {str(self.valid_value)}"
 
 
 class AliasGroup:
@@ -144,8 +144,8 @@ class AliasGroup:
             raise ValueError(f"Repeated valid_value {duplicate_value} not allowed")
 
     def get(self, value: Hashable) -> Union[Any, None]:
-        """Get singular Alias key from group when provided valid alias value. If a
-        valid key is not provided, return None.
+        """Get singular Alias value from group when provided valid alias value. If a
+        valid value is not provided, return None.
 
         Parameters
         ----------
@@ -155,14 +155,14 @@ class AliasGroup:
         Returns
         -------
         Union[Any, None]
-           alias key if valid value, else None
+           alias value if valid value, else None
         """
         option = self.option_map.get(value)
 
         if option is None:
             return None
 
-        return option.key
+        return option.value
 
     @property
     def option_groups(self):

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -102,10 +102,14 @@ class Alias:
 
         return key
 
-    def __or__(self, b):
+    def __or__(self, b) -> Union["Alias", "AliasGroup"]:
         if not isinstance(b, Alias):
             error_message = f"{b} must be type Alias"
             raise TypeError(error_message)
+
+        # value is same between both objects, return new Alias containing union of keys
+        if b.value == self.value:
+            return Alias(self.value, self.keys | b.keys)
 
         return AliasGroup([self, b])
 

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -92,7 +92,7 @@ class Alias:
 
         if value is None:
             raise ValueError(
-                "Invalid value %s. Valid values are %s" % (value, self.keys)
+                f"Invalid value {str(value)}. Valid values are {str(self.keys)}"
             )
 
         return value

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -2,7 +2,7 @@
 
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, Hashable, Iterable, List, Union
+from typing import Callable, Hashable, Iterable, List, Union
 
 # local import
 from ._iterable_nonstring import IterableNonStringLike
@@ -33,7 +33,7 @@ class Alias:
         result = foo_alias["bar"]()
     """
 
-    value: Any
+    value: Union[int, float, str, bytes, bool, Callable, None]
     keys: Union[Iterable, Hashable]
 
     def __post_init__(self):
@@ -52,7 +52,9 @@ class Alias:
             self.__dict__["keys"] = self.keys | self.value.keys
             self.__dict__["value"] = self.value.value
 
-    def get(self, value: Hashable) -> Union[Any, None]:
+    def get(
+        self, value: Hashable
+    ) -> Union[int, float, str, bytes, bool, Callable, None]:
         """Get value given a valid alias value. If a valid value is not provided, return
         None.
 
@@ -63,7 +65,7 @@ class Alias:
 
         Returns
         -------
-        Union[Any, None]
+        Union[int, float, str, bytes, bool, Callable, None]
            alias value if valid value, else None
         """
         if value in self:
@@ -74,7 +76,7 @@ class Alias:
     def __contains__(self, value) -> bool:
         return value in self.keys
 
-    def __getitem__(self, value) -> Any:
+    def __getitem__(self, value) -> Union[int, float, str, bytes, bool, Callable, None]:
         value = self.get(value)
 
         if value is None:
@@ -144,7 +146,9 @@ class AliasGroup:
         if duplicate_value:
             raise ValueError(f"Repeated valid_value {duplicate_value} not allowed")
 
-    def get(self, value: Hashable) -> Union[Any, None]:
+    def get(
+        self, value: Hashable
+    ) -> Union[int, float, str, bytes, bool, Callable, None]:
         """Get singular Alias value from group when provided valid alias value. If a
         valid value is not provided, return None.
 
@@ -155,7 +159,7 @@ class AliasGroup:
 
         Returns
         -------
-        Union[Any, None]
+        Union[int, float, str, bytes, bool, Callable, None]
            alias value if valid value, else None
         """
         option = self.option_map.get(value)

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -33,22 +33,22 @@ class Alias:
     """
 
     value: Any
-    valid_value: Union[Iterable, Hashable]
+    keys: Union[Iterable, Hashable]
 
     def __post_init__(self):
         # Create deep copy so a ref to a mutable value could not change keys implicitly
         self.__dict__["value"] = deepcopy(self.value)
 
-        # If non- str/bytes collection, frozenset, else frozenset([valid_value])
-        self.__dict__["valid_value"] = (
-            frozenset(self.valid_value)
-            if isinstance(self.valid_value, IterableNonStringLike)
-            else frozenset([self.valid_value])
+        # If non- str/bytes collection, frozenset, else frozenset([keys])
+        self.__dict__["keys"] = (
+            frozenset(self.keys)
+            if isinstance(self.keys, IterableNonStringLike)
+            else frozenset([self.keys])
         )
 
         if isinstance(self.value, Alias):
             # Alias is passed as value, use contents to extend into new instance
-            self.__dict__["valid_value"] = self.valid_value | self.value.valid_value
+            self.__dict__["keys"] = self.keys | self.value.keys
             self.__dict__["value"] = self.value.value
 
     def get(self, value: Hashable) -> Union[Any, None]:
@@ -71,14 +71,14 @@ class Alias:
         return None
 
     def __contains__(self, value) -> bool:
-        return value in self.valid_value
+        return value in self.keys
 
     def __getitem__(self, value) -> Any:
         value = self.get(value)
 
         if value is None:
             raise ValueError(
-                "Invalid value %s. Valid values are %s" % (value, self.valid_value)
+                "Invalid value %s. Valid values are %s" % (value, self.keys)
             )
 
         return value
@@ -87,7 +87,7 @@ class Alias:
         return str(self.value)
 
     def __repr__(self):
-        return f"{str(self.value)}: {str(self.valid_value)}"
+        return f"{str(self.value)}: {str(self.keys)}"
 
 
 class AliasGroup:
@@ -132,11 +132,11 @@ class AliasGroup:
         self.option_map = {}
 
         for member in self._option_groups:
-            symmetric_differences = member.valid_value ^ symmetric_differences
-            union = member.valid_value | union
+            symmetric_differences = member.keys ^ symmetric_differences
+            union = member.keys | union
 
-            for valid_value in member.valid_value:
-                self.option_map[valid_value] = member
+            for key in member.keys:
+                self.option_map[key] = member
 
         duplicate_value = union - symmetric_differences
 

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -10,9 +10,9 @@ from ._iterable_nonstring import IterableNonStringLike
 
 @dataclass(frozen=True)
 class Alias:
-    """Create an immutable one to many relationship where a set of keys alias some value. This is often
-    useful in a variety of applications when the API differs from the backend value.
-    This is also useful when writing factories patterns.
+    """Create an immutable many to one relationship where a set of keys alias some
+    value. This is often useful in a variety of applications when the API differs
+    from the backend value. This is also useful when writing factories patterns.
 
     A value can be any scalar, callable, tuple, or frozenset type. At construction,
     value is deepcopied, meaning a value cannot be mutated by reference. Valid alias
@@ -39,7 +39,7 @@ class Alias:
     def __post_init__(self):
 
         scalar_or_callable = Union[
-            int, float, str, bytes, bool, Callable, tuple, frozenset, None
+            int, float, str, bytes, bool, Callable, tuple, frozenset, Alias, None
         ]
 
         if not isinstance(self.value, scalar_or_callable.__args__):
@@ -62,10 +62,10 @@ class Alias:
             self.__dict__["value"] = self.value.value
 
     def get(
-        self, value: Hashable
+        self, key: Hashable
     ) -> Union[int, float, str, bytes, bool, Callable, tuple, frozenset, None]:
-        """Get value given a valid alias value. If a valid value is not provided, return
-        None.
+        """Get value given a valid key. Providing the value or an `Alias` instance is
+        also supported. If a valid value is not provided, return None.
 
         Parameters
         ----------
@@ -75,7 +75,7 @@ class Alias:
         Returns
         -------
         Union[int, float, str, bytes, bool, Callable, tuple, frozenset, None]
-           alias value if valid value, else None
+           alias value if valid key, value, or `Alias` instance, else None
         """
         if value in self:
             return self.value
@@ -125,7 +125,10 @@ class AliasGroup:
 
         path_1 = Alias("path-1", [1, "1"])
         path_2 = Alias("path-2", [2, "2"])
-        path_group = GroupAlias([path_1, path_2])
+        path_group = path_1 or path_2
+
+        # or equivalently (using `or` opporator is recommended):
+        # path_group = GroupAlias([path_1, path_2])
 
         def get_cool_feature(path: Union[int, str]):
             path = path_group[path] # ValueError thrown if invalid path
@@ -165,10 +168,10 @@ class AliasGroup:
             raise ValueError(f"Repeated valid_value {duplicate_value} not allowed")
 
     def get(
-        self, value: Hashable
+        self, key: Hashable
     ) -> Union[int, float, str, bytes, bool, Callable, tuple, frozenset, None]:
-        """Get singular Alias value from group when provided valid alias value. If a
-        valid value is not provided, return None.
+        """Get value of Alias in group from a corresponding key, alias value, or
+        alias instance. If corresponding Alias value is not present, return None.
 
         Parameters
         ----------

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -74,7 +74,14 @@ class Alias:
         return value in self.valid_value
 
     def __getitem__(self, value) -> Any:
-        return self.get(value)
+        key = self.get(value)
+
+        if key is None:
+            raise ValueError(
+                "Invalid value %s. Valid values are %s" % (value, self.valid_value)
+            )
+
+        return key
 
     def __str__(self):
         return str(self.key)

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -134,9 +134,9 @@ class AliasGroup:
 
         path_1 = Alias("path-1", [1, "1"])
         path_2 = Alias("path-2", [2, "2"])
-        path_group = path_1 or path_2
+        path_group = path_1 | path_2
 
-        # or equivalently (using `or` opporator is recommended):
+        # or equivalently (using logical or `|` opporator is recommended):
         # path_group = GroupAlias([path_1, path_2])
 
         def get_cool_feature(path: Union[int, str]):

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -138,7 +138,7 @@ class AliasGroup:
         if duplicate_value:
             raise ValueError(f"Repeated valid_value {duplicate_value} not allowed")
 
-    def get(self, value):
+    def get(self, value: Hashable) -> Union[Any, None]:
         """Get singular Alias key from group when provided valid alias value. If a
         valid key is not provided, return None.
 

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -91,6 +91,30 @@ class Alias:
 
 
 class AliasGroup:
+    """Create a group of Alias objects that are treated like a single Alias. This
+    comes in handy to cut down on conditional statements when developing for example,
+    rest api libraries. This is clearest shown through an example.
+
+    Example:
+        base_url = "www.api.org"
+
+        # In the below, both path-1 and path-2 are different entities.
+        # api.org/path-1/cool-feature
+        # api.org/path-2/cool-feature
+
+        path_1 = Alias("path-1", [1, "1"])
+        path_2 = Alias("path-2", [2, "2"])
+        path_group = GroupAlias([path_1, path_2])
+
+        def get_cool_feature(path: Union[int, str]):
+            path = path_group[path] # ValueError thrown if invalid path
+
+            url = f"{base_url}/{path}/cool-feature"
+
+            response = requests.get(url)
+            return response.json()
+    """
+
     def __init__(self, alias: List[Alias]) -> None:
 
         self._option_groups = (
@@ -115,6 +139,19 @@ class AliasGroup:
             raise ValueError(f"Repeated valid_value {duplicate_value} not allowed")
 
     def get(self, value):
+        """Get singular Alias key from group when provided valid alias value. If a
+        valid key is not provided, return None.
+
+        Parameters
+        ----------
+        value : Hashable
+            Valid alias value
+
+        Returns
+        -------
+        Union[Any, None]
+           alias key if valid value, else None
+        """
         option = self.option_map.get(value)
 
         if option is None:

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -14,11 +14,11 @@ class Alias:
     useful in a variety of applications when the API differs from the backend value.
     This is also useful when writing factories patterns.
 
-    A value can be any scalar or callable type. At construction, value is deepcopied,
-    meaning a value cannot be mutated by reference. Valid alias keys are scalar types
-    and collections of scalar types. Keys are stored in a frozenset, so in the case
-    of passing a dictionary as the keys arg, only the dictionary keys from the passed
-    dictionary will be considered as keys.
+    A value can be any scalar, callable, tuple, or frozenset type. At construction,
+    value is deepcopied, meaning a value cannot be mutated by reference. Valid alias
+    keys are scalar types and collections of scalar types. Keys are stored in a
+    frozenset, so in the case of passing a dictionary as the keys arg, only the
+    dictionary keys from the passed dictionary will be considered as keys.
 
     Examples:
         cms = Alias("cms", ["CMS", "m^3/s"])

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -97,6 +97,13 @@ class Alias:
 
         return value
 
+    def __or__(self, b):
+        if not isinstance(b, Alias):
+            error_message = f"{b} must be type Alias"
+            raise TypeError(error_message)
+
+        return AliasGroup([self, b])
+
     def __str__(self):
         return str(self.value)
 

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -248,6 +248,23 @@ class AliasGroup:
 
         return option
 
+    def __contains__(self, key) -> bool:
+        def instance_and_value(k):
+            if isinstance(k, Alias):
+                return k.value in self.values
+            return False
+
+        return key in self.option_map or key in self.values or instance_and_value(key)
+
+    def __or__(self, b) -> "AliasGroup":
+        accepted_types = (Alias, AliasGroup)
+
+        if not isinstance(b, accepted_types):
+            error_message = f"{b} must be type `Alias` or `AliasGroup`"
+            raise TypeError(error_message)
+
+        return AliasGroup([self, b])
+
     def __str__(self) -> str:
         return str(self.option_groups)
 

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -10,14 +10,15 @@ from ._iterable_nonstring import IterableNonStringLike
 
 @dataclass(frozen=True)
 class Alias:
-    """Create an immutable key, value pair where values alias the key. This is often
+    """Create an immutable one to many relationship where a set of keys alias some value. This is often
     useful in a variety of applications when the API differs from the backend value.
     This is also useful when writing factories patterns.
 
-    Any type is a valid key and is deepcopied at construction, meaning keys cannot be
-    mutated by reference. Valid alias values are single atomic types and collections
-    of atomic types. Values are stored in a frozenset, so in the case of passing a
-    dictionary as a value, on the keys from the passed dictionary will be considered.
+    A value can be any scalar or callable type. At construction, value is deepcopied,
+    meaning a value cannot be mutated by reference. Valid alias keys are scalar types
+    and collections of scalar types. Keys are stored in a frozenset, so in the case
+    of passing a dictionary as the keys arg, only the dictionary keys from the passed
+    dictionary will be considered as keys.
 
     Examples:
         cms = Alias("cms", ["CMS", "m^3/s"])

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any, Hashable, Iterable, Literal, Union
+
+# local import
+from ._iterable_nonstring import IterableNonStringLike
+
+
+@dataclass(frozen=True)
+class Alias:
+    """Create an immutable key, value pair where values alias the key. This is often
+    useful in a variety of applications when the API differs from the backend value.
+    This is also useful when writing factories patterns.
+
+    Any type is a valid key and is deepcopied at construction, meaning keys cannot be
+    mutated by reference. Valid alias values are single atomic types and collections
+    of atomic types. Values are stored in a frozenset, so in the case of passing a
+    dictionary as a value, on the keys from the passed dictionary will be considered.
+
+    Examples:
+        cms = Alias("cms", ["CMS", "m^3/s"])
+
+        cms["CMS"] # returns "cms"
+        cms.get("m^3/s") # returns "cms"
+        "CMS" in cms # returns True
+
+        # foo is callable
+        foo_alias = Alias(foo, ["bar", "baz"])
+
+        result = foo_alias["bar"]()
+    """
+
+    key: Any
+    valid_value: Union[Iterable, Hashable]
+
+    def __post_init__(self):
+        # Create deep copy so a ref to a mutable key could not change value implicitly
+        self.__dict__["key"] = deepcopy(self.key)
+
+        # If non- str/bytes collection, frozenset, else frozenset([valid_value])
+        self.__dict__["valid_value"] = (
+            frozenset(self.valid_value)
+            if isinstance(self.valid_value, IterableNonStringLike)
+            else frozenset([self.valid_value])
+        )
+
+        if isinstance(self.key, Alias):
+            # Alias is passed as key, use contents to extend into new instance
+            self.__dict__["valid_value"] = self.valid_value | self.key.valid_value
+            self.__dict__["key"] = self.key.key
+
+    def get(self, value) -> Any:
+        if value in self:
+            return self.key
+
+        raise ValueError(
+            "Invalid value %s. Valid values are %s" % (value, self.valid_value)
+        )
+
+    def __contains__(self, value) -> bool:
+        return value in self.valid_value
+
+    def __getitem__(self, value) -> Any:
+        return self.get(value)
+
+    def __str__(self):
+        return str(self.key)
+
+    def __repr__(self):
+        return f"{str(self.key)}: {str(self.valid_value)}"

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -117,6 +117,11 @@ class AliasGroup:
 
     def __init__(self, alias: List[Alias]) -> None:
 
+        for item in alias:
+            if not isinstance(item, Alias):
+                error_message = "All items must be type `Alias`"
+                raise ValueError(error_message)
+
         self._option_groups = (
             frozenset(alias)
             if isinstance(alias, IterableNonStringLike)

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -33,10 +33,19 @@ class Alias:
         result = foo_alias["bar"]()
     """
 
-    value: Union[int, float, str, bytes, bool, Callable, None]
+    value: Union[int, float, str, bytes, bool, Callable, tuple, frozenset, None]
     keys: Union[Iterable, Hashable]
 
     def __post_init__(self):
+
+        scalar_or_callable = Union[
+            int, float, str, bytes, bool, Callable, tuple, frozenset, None
+        ]
+
+        if not isinstance(self.value, scalar_or_callable.__args__):
+            error_message = f"value must be type {str(scalar_or_callable.__args__)}"
+            raise ValueError(error_message)
+
         # Create deep copy so a ref to a mutable value could not change keys implicitly
         self.__dict__["value"] = deepcopy(self.value)
 
@@ -54,7 +63,7 @@ class Alias:
 
     def get(
         self, value: Hashable
-    ) -> Union[int, float, str, bytes, bool, Callable, None]:
+    ) -> Union[int, float, str, bytes, bool, Callable, tuple, frozenset, None]:
         """Get value given a valid alias value. If a valid value is not provided, return
         None.
 
@@ -65,7 +74,7 @@ class Alias:
 
         Returns
         -------
-        Union[int, float, str, bytes, bool, Callable, None]
+        Union[int, float, str, bytes, bool, Callable, tuple, frozenset, None]
            alias value if valid value, else None
         """
         if value in self:
@@ -76,7 +85,9 @@ class Alias:
     def __contains__(self, value) -> bool:
         return value in self.keys
 
-    def __getitem__(self, value) -> Union[int, float, str, bytes, bool, Callable, None]:
+    def __getitem__(
+        self, value
+    ) -> Union[int, float, str, bytes, bool, Callable, tuple, frozenset, None]:
         value = self.get(value)
 
         if value is None:
@@ -148,7 +159,7 @@ class AliasGroup:
 
     def get(
         self, value: Hashable
-    ) -> Union[int, float, str, bytes, bool, Callable, None]:
+    ) -> Union[int, float, str, bytes, bool, Callable, tuple, frozenset, None]:
         """Get singular Alias value from group when provided valid alias value. If a
         valid value is not provided, return None.
 
@@ -159,7 +170,7 @@ class AliasGroup:
 
         Returns
         -------
-        Union[int, float, str, bytes, bool, Callable, None]
+        Union[int, float, str, bytes, bool, Callable, tuple, frozenset, None]
            alias value if valid value, else None
         """
         option = self.option_map.get(value)

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -77,25 +77,30 @@ class Alias:
         Union[int, float, str, bytes, bool, Callable, tuple, frozenset, None]
            alias value if valid key, value, or `Alias` instance, else None
         """
-        if value in self:
+        if key in self:
             return self.value
 
         return None
 
-    def __contains__(self, value) -> bool:
-        return value in self.keys
+    def __contains__(self, key) -> bool:
+        def instance_and_value(k):
+            if isinstance(k, Alias):
+                return k.value == self.value
+            return False
+
+        return key in self.keys or key == self.value or instance_and_value(key)
 
     def __getitem__(
-        self, value
+        self, key
     ) -> Union[int, float, str, bytes, bool, Callable, tuple, frozenset, None]:
-        value = self.get(value)
+        key = self.get(key)
 
-        if value is None:
+        if key is None:
             raise ValueError(
-                f"Invalid value {str(value)}. Valid values are {str(self.keys)}"
+                f"Invalid value {str(key)}. Valid values are {str(self.keys)}"
             )
 
-        return value
+        return key
 
     def __or__(self, b):
         if not isinstance(b, Alias):

--- a/python/_restclient/setup.py
+++ b/python/_restclient/setup.py
@@ -13,7 +13,7 @@ SUBPACKAGE_NAME = "_restclient"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "2.0.0-alpha.0"
+VERSION = "2.1.0-alpha.0"
 
 # Package author information
 AUTHOR = "Austin Raney"

--- a/python/_restclient/tests/test_iterable_nonstring.py
+++ b/python/_restclient/tests/test_iterable_nonstring.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import pytest
+from hydrotools._restclient import _iterable_nonstring
+
+
+class FalseMock(str):
+    a = "false_mock"
+
+    def __iter__(self):
+        for c in self.a:
+            yield c
+
+
+false_string_args = [
+    "should fail",
+    b"should fail bytes",
+    str("should fail"),
+    FalseMock(),
+]
+
+
+@pytest.mark.parametrize("arg", false_string_args)
+def test_strings_are_false(arg):
+    assert isinstance(arg, _iterable_nonstring.IterableNonStringLike) is False
+
+
+class TrueMock:
+    a = [1, 2, 3]
+
+    def __iter__(self):
+        for x in self.a:
+            yield x
+
+
+true_args = [list(), dict(), set(), frozenset(), TrueMock()]
+
+
+@pytest.mark.parametrize("arg", true_args)
+def test_true_collection_types(arg):
+    assert isinstance(arg, _iterable_nonstring.IterableNonStringLike) is True

--- a/python/_restclient/tests/test_utilities.py
+++ b/python/_restclient/tests/test_utilities.py
@@ -101,3 +101,20 @@ def test_if_all_items_in_AliasGroup_not_Alias_should_ValueError():
 def test_raise_ValueError_if_non_scalar_or_callable_in_Alias_constructor():
     with pytest.raises(ValueError):
         utilities.Alias(["should-fail"], "please-fail")
+
+
+def test_build_AliasGroup_with_or():
+    true = utilities.Alias(True, [True, 1, "true"])
+    false = utilities.Alias(False, [False, 0, "false"])
+
+    group = true | false
+
+    assert isinstance(group, utilities.AliasGroup)
+
+
+def test_build_AliasGroup_with_or_fail_wrong_type():
+    true = utilities.Alias(True, [True, 1, "true"])
+    false = False
+
+    with pytest.raises(TypeError):
+        group = true | false

--- a/python/_restclient/tests/test_utilities.py
+++ b/python/_restclient/tests/test_utilities.py
@@ -31,7 +31,7 @@ def test_cannot_alter_alias_key(alias_fixture):
         alias_fixture.key = "that"
 
 
-def test_cannot_alter_alias_key(alias_fixture):
+def test_cannot_alter_alias_value(alias_fixture):
     from dataclasses import FrozenInstanceError
 
     with pytest.raises(FrozenInstanceError):

--- a/python/_restclient/tests/test_utilities.py
+++ b/python/_restclient/tests/test_utilities.py
@@ -6,7 +6,7 @@ from hydrotools._restclient import utilities
 
 @pytest.fixture
 def alias_fixture():
-    return utilities.Alias("key", "value")
+    return utilities.Alias("value", "keys")
 
 
 test_instance_args = [
@@ -18,17 +18,10 @@ test_instance_args = [
 ]
 
 
-@pytest.mark.parametrize("key,value", test_instance_args)
-def test_instance_alias(key, value):
+@pytest.mark.parametrize("value,keys", test_instance_args)
+def test_instance_alias(value, keys):
     """ Test inputs that can instantiate the class"""
-    utilities.Alias(key, value)
-
-
-def test_cannot_alter_alias_key(alias_fixture):
-    from dataclasses import FrozenInstanceError
-
-    with pytest.raises(FrozenInstanceError):
-        alias_fixture.key = "that"
+    utilities.Alias(value, keys)
 
 
 def test_cannot_alter_alias_value(alias_fixture):
@@ -38,18 +31,25 @@ def test_cannot_alter_alias_value(alias_fixture):
         alias_fixture.value = "that"
 
 
-def test_pass_mutable_as_key_then_try_to_change_implicitly_by_ref():
-    mute = ["mutable"]
-    inst = utilities.Alias(mute, "value")
+def test_cannot_alter_alias_keys(alias_fixture):
+    from dataclasses import FrozenInstanceError
 
-    assert "mutable" in inst.key
-
-    mute.pop()
-
-    assert "mutable" in inst.key
+    with pytest.raises(FrozenInstanceError):
+        alias_fixture.keys = "that"
 
 
 def test_pass_mutable_as_value_then_try_to_change_implicitly_by_ref():
+    mute = ["mutable"]
+    inst = utilities.Alias(mute, "value")
+
+    assert "mutable" in inst.value
+
+    mute.pop()
+
+    assert "mutable" in inst.value
+
+
+def test_pass_mutable_as_keys_then_try_to_change_implicitly_by_ref():
     mute = ["mutable"]
     inst = utilities.Alias("key", mute)
 
@@ -61,11 +61,11 @@ def test_pass_mutable_as_value_then_try_to_change_implicitly_by_ref():
 
 
 def test_get(alias_fixture):
-    assert alias_fixture.key == alias_fixture.get("value")
+    assert alias_fixture.value == alias_fixture.get("keys")
 
 
 def test__getitem__(alias_fixture):
-    assert alias_fixture.key == alias_fixture["value"]
+    assert alias_fixture.value == alias_fixture["keys"]
 
 
 def test_get_none(alias_fixture):
@@ -100,10 +100,10 @@ def test_alias_group():
     assert group.get(0) is False
     assert group.get("false") is False
 
+
 def test_if_all_items_in_AliasGroup_not_Alias_should_ValueError():
     true = utilities.Alias(True, [True, 1, "true"])
     false = False
 
     with pytest.raises(ValueError):
         utilities.AliasGroup([true, false])
-

--- a/python/_restclient/tests/test_utilities.py
+++ b/python/_restclient/tests/test_utilities.py
@@ -66,28 +66,38 @@ def test__getitem__raises_value_error(alias_fixture):
         alias_fixture["None"]
 
 
-def test_alias_group():
+@pytest.fixture
+def true_false_AG_constructor():
     true = utilities.Alias(True, [True, 1, "true"])
     false = utilities.Alias(False, [False, 0, "false"])
 
-    assert true.get(True) is True
-
+    # ensure instantiation works in both cases
     group = utilities.AliasGroup([true, false])
-    assert group[True] is True
-    assert group[1] is True
-    assert group["true"] is True
+    assert isinstance(group, utilities.AliasGroup)
+    return group
 
-    assert group.get(True) is True
-    assert group.get(1) is True
-    assert group.get("true") is True
 
-    assert group[False] is False
-    assert group[0] is False
-    assert group["false"] is False
+@pytest.fixture
+def true_false_AG_using_or():
+    true = utilities.Alias(True, [True, 1, "true"])
+    false = utilities.Alias(False, [False, 0, "false"])
 
-    assert group.get(False) is False
-    assert group.get(0) is False
-    assert group.get("false") is False
+    group = true | false
+    assert isinstance(group, utilities.AliasGroup)
+    return group
+
+
+@pytest.fixture(
+    params=["true_false_AG_constructor", "true_false_AG_using_or"], name="group"
+)
+def true_false_AG_meta_fixture(request):
+    """Meta fixture returning multiple AG fixtures.  This is like
+    pytest.mark.parametrize, but with fixtures.
+    """
+    # request is a special pytest fixture that returns context information
+    # here, the `getfixturevalue` func is used to get the return value for each
+    # fixture passed in `params`
+    return request.getfixturevalue(request.param)
 
 
 def test_if_all_items_in_AliasGroup_not_Alias_should_ValueError():
@@ -103,13 +113,38 @@ def test_raise_ValueError_if_non_scalar_or_callable_in_Alias_constructor():
         utilities.Alias(["should-fail"], "please-fail")
 
 
-def test_build_AliasGroup_with_or():
-    true = utilities.Alias(True, [True, 1, "true"])
-    false = utilities.Alias(False, [False, 0, "false"])
+def test_AliasGroup_contains(group):
 
-    group = true | false
+    assert True in group
+    assert False in group
 
-    assert isinstance(group, utilities.AliasGroup)
+    assert "true" in group
+    assert "false" in group
+
+    assert 1 in group
+    assert 0 in group
+
+
+def test_AliasGroup__getitem__(group):
+
+    assert group["true"] is True
+    assert group[True] is True
+    assert group[1] is True
+
+    assert group["false"] is False
+    assert group[False] is False
+    assert group[0] is False
+
+
+def test_AliasGroup_get(group):
+
+    assert group.get("true") is True
+    assert group.get(True) is True
+    assert group.get(1) is True
+
+    assert group.get("false") is False
+    assert group.get(False) is False
+    assert group.get(0) is False
 
 
 def test_build_AliasGroup_with_or_fail_wrong_type():
@@ -117,4 +152,67 @@ def test_build_AliasGroup_with_or_fail_wrong_type():
     false = False
 
     with pytest.raises(TypeError):
-        group = true | false
+        true | false
+
+
+def test_Alias_contains():
+    true = utilities.Alias(True, "1")
+    true_2 = utilities.Alias(True, "2")
+    func = utilities.Alias(lambda x: x ** 2, "square")
+
+    assert "1" in true
+    assert True in true
+    assert true in true
+
+    assert "square" in func
+    assert func in func
+    x = lambda x: x ** 2
+    assert (x in func) == False
+
+    assert true_2 in true
+    assert true in true_2
+
+    assert (False in true) == False
+
+
+def test_reinstantiate_Alias_with_Alias_instance():
+    a = utilities.Alias(True, [1, 3])
+    assert a.value == True
+    assert 2 not in a.keys
+
+    b = utilities.Alias(a, [2])
+    assert b.value == True
+    assert 2 in b.keys
+
+
+def test_or_from_same_alias_value():
+    a = utilities.Alias(True, [1, 3])
+    b = utilities.Alias(True, [2, 2, 1])
+    c = a | b
+
+    assert isinstance(c, utilities.Alias)
+    assert 3 not in b
+    assert 2 not in a
+
+    assert 1 in c
+    assert 2 in c
+    assert 3 in c
+
+
+def test_build_AliasGroup_from_same_Alias(group):
+    a = utilities.Alias(False, ["False"])
+
+    # build AliasGroup from AliasGroup and Alias
+    c = group | a
+
+    assert isinstance(c, utilities.AliasGroup)
+    assert "False" in c
+    assert "False" not in group
+
+
+def test_AliasGroup_keys_prop():
+    a = utilities.Alias(True, [1, 3])
+    b = utilities.Alias(False, [4])
+    c = a | b  # AliasGroup
+
+    assert {1, 3, 4}.isdisjoint(c.keys) is False

--- a/python/_restclient/tests/test_utilities.py
+++ b/python/_restclient/tests/test_utilities.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import pytest
+from hydrotools._restclient import utilities
+
+
+@pytest.fixture
+def alias_fixture():
+    return utilities.Alias("key", "value")
+
+
+test_instance_args = [
+    ("this", "that"),
+    (1, 2),
+    (1.0, 2.0),
+    (lambda x: x, (1, 2)),
+    ((1, 2), "key"),
+]
+
+
+@pytest.mark.parametrize("key,value", test_instance_args)
+def test_instance_alias(key, value):
+    """ Test inputs that can instantiate the class"""
+    utilities.Alias(key, value)
+
+
+def test_cannot_alter_alias_key(alias_fixture):
+    from dataclasses import FrozenInstanceError
+
+    with pytest.raises(FrozenInstanceError):
+        alias_fixture.key = "that"
+
+
+def test_cannot_alter_alias_key(alias_fixture):
+    from dataclasses import FrozenInstanceError
+
+    with pytest.raises(FrozenInstanceError):
+        alias_fixture.value = "that"
+
+
+def test_pass_mutable_as_key_then_try_to_change_implicitly_by_ref():
+    mute = ["mutable"]
+    inst = utilities.Alias(mute, "value")
+
+    assert "mutable" in inst.key
+
+    mute.pop()
+
+    assert "mutable" in inst.key
+
+
+def test_pass_mutable_as_value_then_try_to_change_implicitly_by_ref():
+    mute = ["mutable"]
+    inst = utilities.Alias("key", mute)
+
+    assert "mutable" in inst
+
+    mute.pop()
+
+    assert "mutable" in inst
+
+
+def test_get(alias_fixture):
+    assert alias_fixture.key == alias_fixture.get("value")
+
+
+def test__getitem__(alias_fixture):
+    assert alias_fixture.key == alias_fixture["value"]

--- a/python/_restclient/tests/test_utilities.py
+++ b/python/_restclient/tests/test_utilities.py
@@ -38,17 +38,6 @@ def test_cannot_alter_alias_keys(alias_fixture):
         alias_fixture.keys = "that"
 
 
-def test_pass_mutable_as_value_then_try_to_change_implicitly_by_ref():
-    mute = ["mutable"]
-    inst = utilities.Alias(mute, "value")
-
-    assert "mutable" in inst.value
-
-    mute.pop()
-
-    assert "mutable" in inst.value
-
-
 def test_pass_mutable_as_keys_then_try_to_change_implicitly_by_ref():
     mute = ["mutable"]
     inst = utilities.Alias("key", mute)

--- a/python/_restclient/tests/test_utilities.py
+++ b/python/_restclient/tests/test_utilities.py
@@ -99,3 +99,11 @@ def test_alias_group():
     assert group.get(False) is False
     assert group.get(0) is False
     assert group.get("false") is False
+
+def test_if_all_items_in_AliasGroup_not_Alias_should_ValueError():
+    true = utilities.Alias(True, [True, 1, "true"])
+    false = False
+
+    with pytest.raises(ValueError):
+        utilities.AliasGroup([true, false])
+

--- a/python/_restclient/tests/test_utilities.py
+++ b/python/_restclient/tests/test_utilities.py
@@ -75,3 +75,27 @@ def test_get_none(alias_fixture):
 def test__getitem__raises_value_error(alias_fixture):
     with pytest.raises(ValueError):
         alias_fixture["None"]
+
+
+def test_alias_group():
+    true = utilities.Alias(True, [True, 1, "true"])
+    false = utilities.Alias(False, [False, 0, "false"])
+
+    assert true.get(True) is True
+
+    group = utilities.AliasGroup([true, false])
+    assert group[True] is True
+    assert group[1] is True
+    assert group["true"] is True
+
+    assert group.get(True) is True
+    assert group.get(1) is True
+    assert group.get("true") is True
+
+    assert group[False] is False
+    assert group[0] is False
+    assert group["false"] is False
+
+    assert group.get(False) is False
+    assert group.get(0) is False
+    assert group.get("false") is False

--- a/python/_restclient/tests/test_utilities.py
+++ b/python/_restclient/tests/test_utilities.py
@@ -96,3 +96,8 @@ def test_if_all_items_in_AliasGroup_not_Alias_should_ValueError():
 
     with pytest.raises(ValueError):
         utilities.AliasGroup([true, false])
+
+
+def test_raise_ValueError_if_non_scalar_or_callable_in_Alias_constructor():
+    with pytest.raises(ValueError):
+        utilities.Alias(["should-fail"], "please-fail")

--- a/python/_restclient/tests/test_utilities.py
+++ b/python/_restclient/tests/test_utilities.py
@@ -66,3 +66,12 @@ def test_get(alias_fixture):
 
 def test__getitem__(alias_fixture):
     assert alias_fixture.key == alias_fixture["value"]
+
+
+def test_get_none(alias_fixture):
+    assert alias_fixture.get("None") is None
+
+
+def test__getitem__raises_value_error(alias_fixture):
+    with pytest.raises(ValueError):
+        alias_fixture["None"]


### PR DESCRIPTION
## Additions

- `utilities` module under `_restclient` subpackage
- Immutable `Alias` class that accepts a key of any type and a value or collection of values that act as the alias to the key. To get key, use `.get(value) # returns key or None` or `[value] # throws ValueError if invalid value`.
- Immutable `AliasGroup` that supports a collection of `Alias` objects but treats them as a single `Alias`.
- `IterableNonStringLike` type for checking if object is an instance of an iterable type but not a string or byte. string and bytes are iterable in python3.


PR adds `hydrotools._restclient.utilities` which contains: Immutable `Alias` and `AliasGroup` classes. These classes serve to simplify library code where it is common to separate back-end implementation from the front-end api. Often this is applicable when developing a library to access a rest api. 

An concrete use-case for this feature is interfacing with the [USGS NLDI](https://waterdata.usgs.gov/blog/nldi-intro/) [REST api](https://labs.waterdata.usgs.gov/api/nldi/swagger-ui/index.html?configUrl=/api/nldi/v3/api-docs/swagger-config). The NLDI api provides endpoints for accessing to stream and basin features on and along the NHDPlus network from a variety of location metadata providers (USGS NWIS, NHDPlus comid, HUC12 Pour Points, etc.). The api is configured as follows:

```shell
# `location-provider` and `location` are variables to the api
https://labs.waterdata.usgs.gov/api/nldi/linked-data/{{location-provider}}/{{location}}/navigation/
```

Some valid `location-providers` are:
`comid`: NHDplus comid
`nwissite`: USGS NWIS
`huc12pp`: HUC12 Pour Points

As a developer, instead of these "back-end" provider names I would rather my API refer to these `location-providers` as `nhd`, `usgs` or `nwis`, and `huc12`. This could be accomplished in several ways, but this feature addition simplifies the desired behavior.

```python
comid = Alias("comid", "nhd")
nwissite = Alias("nwissite", ["usgs", "nwis"])
huc12pp = Alias("huc12pp", "huc12")

location_provider_group = AliasGroup([comid, nwissite, huc12pp])

# Usage
location_provider_group.get("nhd") # returns "comid"

# Or using bracket notation
location_provider_group["nwis"] # returns "nwissite"

nwissite["usgs"] # returns "nwissite"
```

**All** types are valid as keys, meaning `Alias` could also be used in a factory pattern where the key is a function.


## Testing

1. `Alias` and `AliasGroup` tests added
2. `IterableNonStringLike` tests added


## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
