### PR TITLE
Simplify nwis_client api: `get` method accessable as subpackage level import

### DIFF
--- a/python/nwis_client/hydrotools/nwis_client/__init__.py
+++ b/python/nwis_client/hydrotools/nwis_client/__init__.py
@@ -1,1 +1,4 @@
 from .iv import IVDataService
+
+# Monkeypatch get classmethod so it's accessable at subpackage level
+get = IVDataService.get


### PR DESCRIPTION
This change is up for discussion and I certainly can be persuaded. I think it would be nice to simplify the `nwis_client` api so a user can use the `get` method when importing the subpackage and without having to import `iv`. 

```python
from hydrotools import nwis_client

df = nwis_client.get(
  sites='01646500', 
  startDT='2019-08-01', 
  endDT='2020-08-01'
)
```

This should flatten then overall api. The drawbacks to this are if other nwis rest api functions are desired as future additions, the method name `get` will be reserved for getting nwis data and added functions will have to work around this. Personally if we are to make this change, I think its one we cant really go backwards without really peeving users. However, I do personally prefer a flat api and I think this proposed change could be implemented in other subpackages to flatten out api's for simplicity sake whilst maintaining backwards compatibility.


## Changes

- `nwis_client.IVDataService.get` method now accessible with `nwis_client.get` 

## TODO

- If this feature is desired, update docstrings and readme examples to reflect the change.
- bump minor version


## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
