### PR TITLE
nwis_client now depends on _restclient from pypi

### DIFF
--- a/python/nwis_client/setup.py
+++ b/python/nwis_client/setup.py
@@ -30,7 +30,7 @@ REQUIREMENTS = [
     "numpy",
     "requests",
     "requests-cache",
-    "hydrotools._restclient@ git+https://github.com/NOAA-OWP/hydrotools.git#subdirectory=python/_restclient",
+    "hydrotools._restclient",
 ]
 
 setup(


### PR DESCRIPTION
In reference to #67, there was an issue with unit tests failing because `nwis_client` was pulling it's dep on `_restclient` from github. I suspect this is a product of how dependency resolution is handled with `pip` > 21. 


## Changes

- nwis_client now depends on _restclient from pypi


## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
