### PR TITLE
(WIP) Change restclient from monkey patching

### DIFF
--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -51,8 +51,8 @@ class RestClient:
         if enable_cache:
             try:
                 # Cache requests for 12 hours
-                requests_cache.install_cache(
-                    requests_cache_filename,
+                self._session = requests_cache.CachedSession(
+                    cache_name=requests_cache_filename,
                     backend="sqlite",
                     expire_after=requests_cache_expire_after,
                 )
@@ -61,6 +61,8 @@ class RestClient:
                 error_message = "Something went wrong with setting up `requests_cache`."
                 BaseException(error_message)
                 raise
+        else:
+            self._session = requests.Session()
 
     def get(
         self,
@@ -192,7 +194,7 @@ class RestClient:
             Session
         """
 
-        with requests.Session() as session:
+        with self._session as session:
 
             # retry times and backoff factor (how long to sleep in between
             # retries)

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -118,7 +118,7 @@ class RestClient:
 
         Examples
         --------
-        >>> 
+        >>>
         """
 
         # Handle default headers.
@@ -139,8 +139,12 @@ class RestClient:
         # Build GET request url
         return requests.Request("GET", url, params=parameters).prepare()
 
-    def Get(self, request: requests.PreparedRequest, **kwargs,) -> requests.Response:
-        """ Thin request.Session.get wrapper. Take prepared request and get
+    def Get(
+        self,
+        request: requests.PreparedRequest,
+        **kwargs,
+    ) -> requests.Response:
+        """Thin request.Session.get wrapper. Take prepared request and get
         response handling errors along the way. Only requests status codes
         200 and 201 returned.If the initial request fails, `self._retries`
         number retries are attempted with a 0.1 backoff factor.
@@ -152,7 +156,7 @@ class RestClient:
         kwargs :
             Keyword arguments passed to requests.Session().send
             See: https://requests.readthedocs.io/en/latest/_modules/requests/sessions/#Session.send
-            
+
 
         Returns
         -------

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -39,15 +39,16 @@ class RestClient:
         self,
         base_url: Union[str, None] = None,
         headers: Union[dict, None] = None,
-        requests_cache_filename: Union[str, None] = None,
+        requests_cache_filename: Union[str, None] = "cache",
         requests_cache_expire_after: int = 43200,
         retries: int = 3,
+        enable_cache: bool = True,
     ):
         self._base_url = base_url
         self._headers = headers
         self._retires = retries
 
-        if requests_cache_filename:
+        if enable_cache:
             try:
                 # Cache requests for 12 hours
                 requests_cache.install_cache(

--- a/python/_restclient/setup.py
+++ b/python/_restclient/setup.py
@@ -13,7 +13,7 @@ SUBPACKAGE_NAME = "_restclient"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "2.1.0-alpha.0"
+VERSION = "2.2.0-alpha.0"
 
 # Package author information
 AUTHOR = "Austin Raney"

--- a/python/_restclient/tests/test_restclient.py
+++ b/python/_restclient/tests/test_restclient.py
@@ -109,10 +109,12 @@ def prepared_request_patch(*args, status_code=404, **kwargs):
 
 @pytest.mark.parametrize("status_code", [200, 201])
 def test_get_request(empty_restclient, monkeypatch, status_code):
-    import requests
+    import requests_cache
 
     monkeypatch.setattr(
-        requests.Session, "send", prepared_request_patch(status_code=status_code)
+        requests_cache.CachedSession,
+        "send",
+        prepared_request_patch(status_code=status_code),
     )
 
     assert empty_restclient.Get(None).status_code == status_code
@@ -122,11 +124,14 @@ def test_get_request(empty_restclient, monkeypatch, status_code):
 def test_get_request_exceptions(empty_restclient, monkeypatch, status_code):
     """ Verify that requests.exceptions.ConnectionError is raised """
     import requests
+    import requests_cache
 
     with pytest.raises(requests.exceptions.ConnectionError):
         req = requests.Request("GET", "http://test-url.test/")
 
         monkeypatch.setattr(
-            requests.Session, "send", prepared_request_patch(status_code=status_code)
+            requests_cache.CachedSession,
+            "send",
+            prepared_request_patch(status_code=status_code),
         )
         empty_restclient.Get(req)


### PR DESCRIPTION
In relation to #14 and #70. `_restclient` no longer uses `requests_cache.install_cache` which monkeypatches the `requests` library. Instead, `requests_cache.CachedSession` is now used. `enable_cache` [bool] parameter added to constructor of `RestClient`

## Changes

- `requests_cache.install_cache` is no longer used. Instead `requests_cache.CachedSession` is now used.
- `enable_cache` [bool] parameter added to constructor of `RestClient`

## Notes

- Passes all unittests, however several slow tests for `nwis_client` are now failing. There appears to be something happening with multiprocessing and the `requests_cache.CachedSession` module.

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
