### PR TITLE
Major refactor of RestClient

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip pytest coverage coverage-badge
+        python -m pip install --upgrade pip pytest pytest-aiohttp coverage coverage-badge
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         python setup.py develop
     - name: Run all unittests 

--- a/python/_restclient/README.md
+++ b/python/_restclient/README.md
@@ -1,13 +1,30 @@
 # HydroTools :: REST Client
 
-This subpackage contains classes and utilities suitable for quickly developing robust
-REST api interfaces. The primary feature of this subpackage is the generic
-`RestClient` class which offers sqlite database GET request caching, GET request
-backoff, and flexible url argument encoding. Immutable `Alias` and `AliasGroup`
-utility classes support common library development patterns aiding in the separation
-of backend and frontend code. See the [REST Client
-Documentation](https://noaa-owp.github.io/hydrotools/hydrotools._restclient.html) for
-a complete list and description of the currently available methods. To report bugs or
+Subpackage of objects and utilities suitable for quickly developing robust
+REST api libraries.
+
+Main features:
+
+- `RestClient`: a class which offers asynchronous performance via a convenient serial
+  wrapper, sqlite database GET request caching, GET request backoff, batch GET requests,
+  and flexible url argument encoding.
+
+- `Url`: Treat urls like to `pathlib.Path`s. Supports appending paths with `/` and
+  appending url query parameters with `+`.
+
+- `ClientSession`: Extension of
+  [`aiohttp_client_cache`](https://github.com/JWCook/aiohttp-client-cache) that adds
+  exponential backoff.
+
+- `Variadic`: Join list or tuple of objects on some delimiter. Useful when query
+  parameters utilize a non-`key=value&key=value2` pattern.
+
+- `Alias` and `AliasGroup`: Immutable utility classes that simplify common API library
+  development patterns (i.e. separation of backend uris from front end interfaces).
+
+See the [REST Client
+Documentation](https://noaa-owp.github.io/hydrotools/hydrotools._restclient.html) for a
+complete list and description of the currently available methods. To report bugs or
 request new features, submit an issue through the [HydroTools Issue
 Tracker](https://github.com/NOAA-OWP/hydrotools/issues) on GitHub.
 
@@ -55,9 +72,9 @@ class BaconIpsum:
     def __init__(self):
         self._restclient = _restclient.RestClient(
             self._base_url,
-            requests_cache_filename="bacon_ipsum_cache",
-            requests_cache_expire_after=43200,
-            retries=5,
+            cache_filename="bacon_ipsum_cache",
+            cache_expire_after=43200, # in seconds
+            n_retries=5,
         )
 
     @classmethod

--- a/python/_restclient/hydrotools/_restclient/__init__.py
+++ b/python/_restclient/hydrotools/_restclient/__init__.py
@@ -1,3 +1,4 @@
 from ._restclient import RestClient
 from .utilities import Alias, AliasGroup
-from . import utilities
+from .urllib import Url, Variadic
+from .async_client import ClientSession

--- a/python/_restclient/hydrotools/_restclient/_iterable_nonstring.py
+++ b/python/_restclient/hydrotools/_restclient/_iterable_nonstring.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 from abc import ABCMeta, abstractmethod
 
 __all__ = ["IterableNonStringLike"]

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -136,7 +136,7 @@ class RestClient(AsyncToSerialHelper):
 
     @MGET_SIGNATURE
     def mget(self, urls, *, parameters, headers, **kwargs):
-        """Make multiple asynchronous GET request. If base url is set, each url is
+        """Make multiple asynchronous GET requests. If base url is set, each url is
         appended to the base url. Passed headers are given precedent over instance
         headers(if present), meaning passed headers replace instance headers with
         matching keys.

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -103,7 +103,7 @@ class RestClient(AsyncToSerialHelper):
         # wrap ClientSession in coroutine and call in event loop
         self._session = self._add_to_loop(
             self._wrap_func_in_coro(
-                ClientSession, cache=cache, retry=retry, n_retries=retries
+                ClientSession, cache=cache, retry=retry, n_retries=n_retries
             )()
         )  # type: ClientSession
 

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -5,7 +5,7 @@ specific use cases.
 # TODO: Add more information about the class here
 """
 
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Tuple, Union
 from collections.abc import Iterable
 import asyncio
 from aiohttp_client_cache import SQLiteBackend

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -37,6 +37,7 @@ class RestClient:
 
     def __init__(
         self,
+        *,
         base_url: Union[str, None] = None,
         headers: Union[dict, None] = None,
         requests_cache_filename: Union[str, None] = None,

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -172,7 +172,13 @@ class RestClient(AsyncToSerialHelper):
         # add query parameters and get quoted representation
         url = (Url(url) + parameters).quote_url
 
-        resp = await self._session.get(url, headers=headers, **kwargs)
+        # Fast way to merge dicts https://stackoverflow.com/a/1784128
+        # Create copy of instance headers, merge headers with instance header copy.
+        # Headers passed to _get have precedent over instance headers
+        _headers = dict(self.headers)
+        _headers.update(headers)
+
+        resp = await self._session.get(url, headers=_headers, **kwargs)
 
         # Verify origin of response. Attr not in aiohttp.ClientSession, thus default None.
         from_cache = getattr(resp, "from_cache", None)

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -40,9 +40,11 @@ class RestClient:
         *,
         base_url: Union[str, None] = None,
         headers: Union[dict, None] = None,
+        enable_cache: bool = True,
         requests_cache_filename: Union[str, None] = None,
         requests_cache_expire_after: int = 43200,
         retries: int = 3,
+        loop: asyncio.AbstractEventLoop = None,
     ):
         self._base_url = base_url
         self._headers = headers

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -1,62 +1,94 @@
-"""
-Generic REST Api client usable/inheritable for general usage and adaptable to more
-specific use cases.
+#!/usr/bin/env python3
 
-# TODO: Add more information about the class here
-"""
-
-from typing import Any, Dict, List, Tuple, Union
-from collections.abc import Iterable
+from typing import Any, List, Union
 import asyncio
 from aiohttp_client_cache import SQLiteBackend
-
-import requests
-import requests_cache
-from urllib3.util.retry import Retry
+import aiohttp
+import forge
+import atexit
 
 # local imports
 from .async_client import ClientSession
 from .async_helpers import AsyncToSerialHelper
+from .urllib import Url
+from ._restclient_sigs import GET_SIGNATURE, MGET_SIGNATURE
+
+__all__ = ["RestClient"]
 
 
 class RestClient(AsyncToSerialHelper):
-    """Provides various methods for constructing requests, retrieving data, and
-    parsing responses from the NWIS IV Service.
+    """
+    Class adept for supporting and simplifying RESTful client libraries and retrieval
+    scripts. Behind the scenes requests are made asynchronously, however the API is
+    exposed using serial methods to simplify usage.
+
+    Features
+    --------
+    - Base url
+    - SQLite request cache
+    - Retry exponential backoff
+    - Serial wrapper methods that make requests asynchronously (see `RestClient.mget`)
 
     Parameters
     ----------
-    processes : int
-        Max multiprocessing processes, default 3
-    retry : int
-        Max number of, per request retries, default 3
-    """
+    base_url: Union[str, Url, None], default None
+        Request base url
+    headers: dict, default {}
+        Headers included in every request
+    enable_cache: bool, default True
+        Enable or disable caching
+    requests_cache_filename: str, default "cache"
+        Cache filename with .sqlite filetype suffix
+    requests_cache_expire_after: int, default 43200
+        Cached request life in seconds
+    retry: bool, default True
+        Enable exponential backoff
+    n_retries: int, default 3
+        Attempt retries n times before failing
+    loop: asyncio.AbstractEventLoop, default None
+        Async event loop
 
-    _response_codes = {
-        200: "OK",
-        304: "Not_Modified",
-        400: "Bad_Request",
-        403: "Access_Forbidden",
-        404: "Not_Found",
-        500: "Internal_Server_Error",
-        503: "Service_Unavailable",
-    }
+    Examples
+    --------
+
+    Simple Request
+    >>> from hydrotools._restclient import RestClient
+    >>>
+    >>> client = RestClient()
+    >>> resp = client.get("weather.gov")
+    >>> print(resp.text())
+
+
+    USGS NLDI Requests
+    >>> from hydrotools._restclient import RestClient
+    >>>
+    >>> base_url = "https://labs.waterdata.usgs.gov/api/nldi/linked-data/nwissite/"
+    >>> headers = {"Accept": "*/*", "Accept-Encoding": "gzip, compress"}
+    >>> client = RestClient(base_url=base_url, headers=headers)
+    >>>
+    >>> sites = ["0423360405", "05106000","05078520","05078470","05125039","05124982"]
+    >>> site_urls = [f"/USGS-{site}/navigation/UT/flowlines" for site in sites]
+    >>> requests = client.mget(site_urls)
+    >>> requests = [resp.json() for resp in requests]
+    """
 
     def __init__(
         self,
         *,
-        base_url: Union[str, None] = None,
-        headers: Union[dict, None] = None,
+        base_url: Union[str, Url, None] = None,
+        headers: dict = {},
         enable_cache: bool = True,
         requests_cache_filename: str = "cache",
         requests_cache_expire_after: int = 43200,
         retry: bool = True,
-        retries: int = 3,
+        n_retries: int = 3,
         loop: asyncio.AbstractEventLoop = None,
     ):
-        super().__init__(loop)  # implicitly adds self._loop
-        self._base_url = base_url
+        # implicitly adds self._loop and gets loop if None provided
+        super().__init__(loop)
+        self._base_url = Url(base_url) if base_url is not None else None
         self._headers = headers
-        self._retires = retries
+        self._retires = n_retries
         self._cache_enabled = enable_cache
 
         cache = None
@@ -68,155 +100,112 @@ class RestClient(AsyncToSerialHelper):
                 allowed_methods=["GET"],
             )
 
+        # wrap ClientSession in coroutine and call in event loop
         self._session = self._add_to_loop(
-            ClientSession(cache=cache, retry=retry, n_retries=retries)
+            self._wrap_func_in_coro(
+                ClientSession, cache=cache, retry=retry, n_retries=retries
+            )()
+        )  # type: ClientSession
+
+        # register session removal at normal exit
+        atexit.register(self.release_session)
+
+    @GET_SIGNATURE
+    def get(self, url, *, parameters, headers, **kwargs):
+        """Make GET request. If base url is set, url is appended to the base url.
+        Likewise for request headers.
+
+        Parameters
+        ----------
+        url : str, Url
+            Request url
+        parameters : Dict[str, Union[str, List[str, int, float]]]
+            Query parameters
+        headers : Dict[str, str]
+            Request headers, if RestClient headers set provided headers are appended
+
+        Returns
+        -------
+        aiohttp.ClientResponse
+        """
+
+        return self._add_to_loop(
+            self._get(url, parameters=parameters, headers=headers, **kwargs)
         )
 
-    def get(
+    @MGET_SIGNATURE
+    def mget(self, urls, *, parameters, headers, **kwargs):
+        """Make multiple asynchronous GET request. If base url is set, each url is
+        appended to the base url.  Likewise for request headers.
+
+        Parameters
+        ----------
+        urls : List[Union[str, Url]]
+            Request urls
+        parameters : Dict[str, Union[str, List[str, int, float]]]
+            Query parameters
+        headers : Dict[str, str]
+            Request headers, if RestClient headers set provided headers are appended
+
+        Returns
+        -------
+        List[aiohttp.ClientResponse]
+        """
+        return self._add_to_loop(
+            self._mget(urls, parameters=parameters, headers=headers, **kwargs)
+        )
+
+    @GET_SIGNATURE
+    async def _get(
         self,
         url: str = None,
-        parameters: dict = None,
-        headers: dict = None,
-        parameter_delimeter: str = None,
+        *,
+        parameters,
+        headers,
         **kwargs,
-    ):
-        if not isinstance(url, str):
-            if not isinstance(self._base_url, str):
-                error_message = "A base_url was not set nor was a url passed."
-                raise AttributeError(error_message)
+    ) -> aiohttp.ClientResponse:
+        if self.base_url is not None:
+            url = self._base_url / url
 
-            url = self._base_url
+        # add query parameters and get quoted representation
+        url = (Url(url) + parameters).quote_url
 
-        request = self.Request(
-            url=url,
-            parameters=parameters,
-            headers=headers,
-            parameter_delimiter=parameter_delimeter,
-        )
-        return self.Get(request, **kwargs)
+        resp = await self._session.get(url, headers=headers, **kwargs)
 
-    def Request(
+        # implicitly sets resp._body which contains response data
+        await resp.read()
+
+        # release the resource
+        # note, resp is "locked" until released meaning it cannot be patched until post-release
+        resp.release()
+        # Patch and wrap resp's, text and json methods with run_until_complete and forge their signatures
+        resp = self._patch_get(resp)
+        return resp
+
+    @MGET_SIGNATURE
+    async def _mget(
         self,
-        url: str = None,
-        parameters: Dict[str, Union[str, List[Any]]] = None,
-        parameter_delimiter: Union[str, None] = None,
-        headers: Dict[str, str] = None,
-    ) -> requests.PreparedRequest:
-        """Create Prepared Request from url and parameters and headers. Parameter
-        concatenation behavior can be changed by passing a different
-        `parameter_delimiter` argument. For example, a comma could be specified for
-        USGS. (i.e. https://example-site.com/?var=1,2,3)
+        urls,
+        *args,
+        **kwargs: Any,
+    ) -> List[aiohttp.ClientResponse]:
+        return await asyncio.gather(*[self._get(url, *args, **kwargs) for url in urls])
 
-        Parameters
-        ----------
-        url : str, optional
-            url on which parameters are appended, by default self._base_url
-        parameters : Dict[str, Union[str, List[Any]], optional
-            parameters to append to url, by default None
-        parameter_delimiter : Union[str, None], optional
-            delimiter to separate parameters.
-            None will resume normal Requests behavior, by default ","
-        headers : Dict[str, str], optional
-            headers, by default None
+    def _patch_get(
+        self, client_response: aiohttp.ClientResponse
+    ) -> aiohttp.ClientResponse:
+        """ Wrap aiohttp.ClientResponse text and json coros in run_until_complete. Monkeypatch text and json with wrappers."""
+        # May iter through methods and wrap all coro's in the future
+        # however that may not work if a non-coro returns a async context manager for example
+        text = self._wrap_coro_in_callable(client_response.text)
+        json = self._wrap_coro_in_callable(client_response.json)
+        # resign signatures
+        text = forge.copy(aiohttp.ClientResponse.text, exclude="self")(text)
+        json = forge.copy(aiohttp.ClientResponse.json, exclude="self")(json)
 
-        Returns
-        -------
-        requests.PreparedRequest
-            Prepared requests object
-
-        Examples
-        --------
-        >>> 
-        """
-
-        # Handle default headers.
-        if not isinstance(headers, dict):
-            headers = {}
-
-        if parameters and parameter_delimiter:
-            # Join key parameters that are in a list with delimiter
-            # `parameter_delimiter`
-            for key, value in parameters.items():
-                if isinstance(value, Iterable) and not isinstance(value, str):
-                    try:
-                        parameters[key] = f"{parameter_delimiter}".join(value)
-                    except TypeError:
-                        value = map(str, value)
-                        parameters[key] = f"{parameter_delimiter}".join(value)
-
-        # Build GET request url
-        return requests.Request("GET", url, params=parameters).prepare()
-
-    def Get(self, request: requests.PreparedRequest, **kwargs,) -> requests.Response:
-        """ Thin request.Session.get wrapper. Take prepared request and get
-        response handling errors along the way. Only requests status codes
-        200 and 201 returned.If the initial request fails, `self._retries`
-        number retries are attempted with a 0.1 backoff factor.
-
-        Parameters
-        ----------
-        request : requests.PreparedRequest
-            Prepared request object. Header and url are included
-        kwargs :
-            Keyword arguments passed to requests.Session().send
-            See: https://requests.readthedocs.io/en/latest/_modules/requests/sessions/#Session.send
-            
-
-        Returns
-        -------
-        requests.Response
-            request.Session.get response.
-
-        Raises
-        ------
-        requests.exceptions.ConnectionError
-           Raise if receive non 200 or 201 response
-        """
-        try:
-            with self._create_session() as session:
-                response = session.send(request, **kwargs)
-
-                if response.status_code == 201 or response.status_code == 200:
-                    return response
-
-                # Failed to retrieve
-                error_message = (
-                    "Retrieval failed\n"
-                    + f"Server code: {response.status_code}\n"
-                    + f"Server status: {self._response_codes[response.status_code]}\n"
-                    + f"Query url:\n{request.url}"
-                )
-                raise requests.exceptions.ConnectionError(error_message)
-
-        except requests.ConnectionError:
-            error_message = f"Verify the {request.url} is correct"
-            BaseException(error_message)
-            raise
-
-    def _create_session(self):
-        """Create requests.Session object with concrete retry strategy.
-
-        Returns
-        -------
-        requests.Session
-            Session
-        """
-
-        with requests.Session() as session:
-
-            # retry times and backoff factor (how long to sleep in between
-            # retries)
-            retires = Retry(
-                total=self._retires,
-                backoff_factor=0.1,
-                status_forcelist=[500, 502, 503, 504],
-            )
-
-            session.mount(
-                "https://", requests.adapters.HTTPAdapter(max_retries=retires)
-            )
-
-            return session
+        client_response.text = text
+        client_response.json = json
+        return client_response
 
     @property
     def base_url(self) -> str:
@@ -228,26 +217,11 @@ class RestClient(AsyncToSerialHelper):
         """ GET request headers """
         return self._headers
 
+    def release_session(self) -> None:
+        """ Release aiohttp.ClientSession """
+        if not self._session.closed:
+            self._add_to_loop(self._session.close())
 
-class Variadic(str):
-    """Specify list or tuple as delimeted str. The is useful when specifying arguments
-    in a URL that do not conform to the &key=value&key=value2 convention.
-
-    Example:
-        url = "https://www.test.gov",
-        async with ClientSession() as session:
-            async with session.get(url,
-                params={"this": Variadic(["that", "the", "other"])},
-            ) as req:
-                print(req.url) # Returns, https://www.test.gov/?this=that,the,other
-
-    """
-
-    def __init__(self, values: Union[List, Tuple], *, delimeter: str = ",") -> None:
-        self.values = delimeter.join([str(v) for v in values])
-
-    def __repr__(self):
-        return self.values
-
-    def __str__(self) -> str:
-        return repr(self)
+    def __del__(self) -> None:
+        atexit.unregister(self.release_session)
+        self.release_session()

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -37,9 +37,9 @@ class RestClient(AsyncToSerialHelper):
         Headers included in every request
     enable_cache: bool, default True
         Enable or disable caching
-    requests_cache_filename: str, default "cache"
+    cache_filename: str, default "cache"
         Cache filename with .sqlite filetype suffix
-    requests_cache_expire_after: int, default 43200
+    cache_expire_after: int, default 43200
         Cached request life in seconds
     retry: bool, default True
         Enable exponential backoff
@@ -78,8 +78,8 @@ class RestClient(AsyncToSerialHelper):
         base_url: Union[str, Url, None] = None,
         headers: dict = {},
         enable_cache: bool = True,
-        requests_cache_filename: str = "cache",
-        requests_cache_expire_after: int = 43200,
+        cache_filename: str = "cache",
+        cache_expire_after: int = 43200,
         retry: bool = True,
         n_retries: int = 3,
         loop: asyncio.AbstractEventLoop = None,
@@ -94,8 +94,8 @@ class RestClient(AsyncToSerialHelper):
         cache = None
         if enable_cache is True:
             cache = SQLiteBackend(
-                cache_name=requests_cache_filename,
-                expire_after=requests_cache_expire_after,
+                cache_name=cache_filename,
+                expire_after=cache_expire_after,
                 allowed_codes=[200],
                 allowed_methods=["GET"],
             )

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -115,7 +115,8 @@ class RestClient(AsyncToSerialHelper):
     @GET_SIGNATURE
     def get(self, url, *, parameters, headers, **kwargs):
         """Make GET request. If base url is set, url is appended to the base url.
-        Likewise for request headers.
+        Passed headers are given precedent over instance headers(if present), meaning
+        passed headers replace instance headers with matching keys.
 
         Parameters
         ----------
@@ -138,7 +139,9 @@ class RestClient(AsyncToSerialHelper):
     @MGET_SIGNATURE
     def mget(self, urls, *, parameters, headers, **kwargs):
         """Make multiple asynchronous GET request. If base url is set, each url is
-        appended to the base url.  Likewise for request headers.
+        appended to the base url. Passed headers are given precedent over instance
+        headers(if present), meaning passed headers replace instance headers with
+        matching keys.
 
         Parameters
         ----------

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -7,13 +7,19 @@ specific use cases.
 
 from typing import Any, Dict, List, Union
 from collections.abc import Iterable
+import asyncio
+from aiohttp_client_cache import SQLiteBackend
 
 import requests
 import requests_cache
 from urllib3.util.retry import Retry
 
+# local imports
+from .async_client import ClientSession
+from .async_helpers import AsyncToSerialHelper
 
-class RestClient:
+
+class RestClient(AsyncToSerialHelper):
     """Provides various methods for constructing requests, retrieving data, and
     parsing responses from the NWIS IV Service.
 

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 from typing import Any, List, Union
 import asyncio
 from aiohttp.client_reqrep import ClientResponse

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -169,7 +169,13 @@ class RestClient(AsyncToSerialHelper):
         headers,
         **kwargs,
     ) -> aiohttp.ClientResponse:
-        if self.base_url is not None:
+        if url is None:
+            if self.base_url is None:
+                raise ValueError("no url provided and no base url set")
+            # only base url
+            url = self._base_url
+
+        elif self.base_url is not None:
             url = self._base_url / url
 
         # add query parameters and get quoted representation

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -18,9 +18,9 @@ __all__ = ["RestClient"]
 
 class RestClient(AsyncToSerialHelper):
     """
-    Class adept for supporting and simplifying RESTful client libraries and retrieval
-    scripts. Behind the scenes requests are made asynchronously, however the API is
-    exposed using serial methods to simplify usage.
+    Class that simplifies writing RESTful client libraries and retrieval scripts. Behind
+    the scenes requests are made asynchronously, however the API is exposed using serial
+    methods to simplify usage.
 
     Features
     --------

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -227,3 +227,27 @@ class RestClient(AsyncToSerialHelper):
     def headers(self) -> dict:
         """ GET request headers """
         return self._headers
+
+
+class Variadic(str):
+    """Specify list or tuple as delimeted str. The is useful when specifying arguments
+    in a URL that do not conform to the &key=value&key=value2 convention.
+
+    Example:
+        url = "https://www.test.gov",
+        async with ClientSession() as session:
+            async with session.get(url,
+                params={"this": Variadic(["that", "the", "other"])},
+            ) as req:
+                print(req.url) # Returns, https://www.test.gov/?this=that,the,other
+
+    """
+
+    def __init__(self, values: Union[List, Tuple], *, delimeter: str = ",") -> None:
+        self.values = delimeter.join([str(v) for v in values])
+
+    def __repr__(self):
+        return self.values
+
+    def __str__(self) -> str:
+        return repr(self)

--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -212,10 +212,26 @@ class RestClient(AsyncToSerialHelper):
     async def _mget(
         self,
         urls,
-        *args,
+        *,
+        parameters,
+        headers,
         **kwargs: Any,
     ) -> List[aiohttp.ClientResponse]:
-        return await asyncio.gather(*[self._get(url, *args, **kwargs) for url in urls])
+        if parameters:
+            assert len(parameters) == len(urls)
+        if headers:
+            assert len(headers) == len(urls)
+
+        return await asyncio.gather(
+            *[
+                self._get(
+                    url,
+                    parameters=parameters[idx] if parameters else {},
+                    headers=headers[idx] if headers else {},
+                )
+                for idx, url in enumerate(urls)
+            ]
+        )
 
     def _patch_get(
         self, client_response: aiohttp.ClientResponse

--- a/python/_restclient/hydrotools/_restclient/_restclient_sigs.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient_sigs.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import forge
+import aiohttp
+from typing import Dict, List, Union
+
+# RestClient signature decorators
+
+_PARAM_HEADER_KWOS = forge.insert(
+    [
+        forge.kwo("parameters", default={}, type=Dict[str, Union[str, List[str]]]),
+        forge.kwo("headers", default={}, type=Dict[str, str]),
+    ],
+    before=lambda arg: arg.kind == forge.FParameter.VAR_KEYWORD,
+)
+
+GET_SIGNATURE = forge.compose(
+    forge.copy(aiohttp.ClientSession.get),
+    forge.returns(aiohttp.ClientResponse),
+    _PARAM_HEADER_KWOS,
+)
+
+MGET_SIGNATURE = forge.compose(
+    forge.copy(aiohttp.ClientSession.get, exclude="url"),
+    forge.returns(List[aiohttp.ClientResponse]),
+    forge.insert(
+        forge.pok("urls", type=forge.fsignature(aiohttp.ClientSession.get)["url"].type),
+        index=1,
+    ),
+    _PARAM_HEADER_KWOS,
+)

--- a/python/_restclient/hydrotools/_restclient/_restclient_sigs.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient_sigs.py
@@ -5,26 +5,37 @@ from typing import Dict, List, Union
 
 # RestClient signature decorators
 
-_PARAM_HEADER_KWOS = forge.insert(
-    [
-        forge.kwo("parameters", default={}, type=Dict[str, Union[str, List[str]]]),
-        forge.kwo("headers", default={}, type=Dict[str, str]),
-    ],
-    before=lambda arg: arg.kind == forge.FParameter.VAR_KEYWORD,
-)
-
 GET_SIGNATURE = forge.compose(
     forge.copy(aiohttp.ClientSession.get),
+    forge.modify("url", default=None),
     forge.returns(aiohttp.ClientResponse),
-    _PARAM_HEADER_KWOS,
+    forge.insert(
+        [
+            forge.kwo("parameters", default={}, type=Dict[str, Union[str, List[str]]]),
+            forge.kwo("headers", default={}, type=Dict[str, str]),
+        ],
+        before=lambda arg: arg.kind == forge.FParameter.VAR_KEYWORD,
+    ),
 )
 
 MGET_SIGNATURE = forge.compose(
     forge.copy(aiohttp.ClientSession.get, exclude="url"),
     forge.returns(List[aiohttp.ClientResponse]),
     forge.insert(
-        forge.pok("urls", type=forge.fsignature(aiohttp.ClientSession.get)["url"].type),
+        forge.pok(
+            "urls",
+            type=forge.fsignature(aiohttp.ClientSession.get)["url"].type,
+            default=None,
+        ),
         index=1,
     ),
-    _PARAM_HEADER_KWOS,
+    forge.insert(
+        [
+            forge.kwo(
+                "parameters", default={}, type=List[Dict[str, Union[str, List[str]]]]
+            ),
+            forge.kwo("headers", default={}, type=List[Dict[str, str]]),
+        ],
+        before=lambda arg: arg.kind == forge.FParameter.VAR_KEYWORD,
+    ),
 )

--- a/python/_restclient/hydrotools/_restclient/_restclient_sigs.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient_sigs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import forge
 import aiohttp
 from typing import Dict, List, Union

--- a/python/_restclient/hydrotools/_restclient/async_client.py
+++ b/python/_restclient/hydrotools/_restclient/async_client.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+from aiohttp_client_cache import CachedSession
+import asyncio
+import forge
+from functools import partial
+from inspect import Parameter
+from random import random
+import warnings
+
+__all__ = ["ClientSession"]
+
+RETRY_STATUS_CODES = frozenset({503, 429, 301})
+
+
+def forge_client_session(init):
+    """ Forge CachedSession.__init__ method signature """
+    forged_signature = forge.compose(
+        forge.copy(CachedSession.__init__),
+        forge.insert(
+            [
+                forge.kwarg("retry", default=True, type=bool),
+                forge.kwarg("n_retries", default=3, type=int),
+            ],
+            before=lambda x: x.kind == Parameter.KEYWORD_ONLY,
+        ),
+    )(init)
+    return forged_signature
+
+
+with warnings.catch_warnings():
+    # Ignore aiohttp.ClientSession Inheritance warning
+    warnings.filterwarnings(
+        "ignore", category=DeprecationWarning, message="Inheritance class"
+    )
+
+    class ClientSession(CachedSession):
+        @forge_client_session
+        def __init__(self, *, retry: bool = True, n_retries: int = 3, **kwargs):
+
+            self._retry = retry
+            self._n_retries = n_retries
+            super().__init__(**kwargs)
+
+        @forge.copy(CachedSession._request)
+        async def _request(self, *args, **kwargs):
+            bound_resp = partial(super()._request, *args, **kwargs)
+            resp = await bound_resp()
+
+            if (
+                self._retry is True
+                and resp.status in RETRY_STATUS_CODES
+                and self._n_retries > 0
+            ):
+                resp = await backoff(bound_resp, self._n_retries)
+
+            return resp
+
+
+async def backoff(request, n: int = 3):
+    resp = None
+    for nth in range(n):
+        resp = await request()
+
+        if resp.status not in RETRY_STATUS_CODES:
+            break  # break, return resp
+        # Exponential backoff
+        sleep_length = (2 ** nth) + (random() / 10)
+        await asyncio.sleep(sleep_length)
+
+    return resp

--- a/python/_restclient/hydrotools/_restclient/async_client.py
+++ b/python/_restclient/hydrotools/_restclient/async_client.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 from aiohttp_client_cache import CachedSession
 import asyncio
 import forge

--- a/python/_restclient/hydrotools/_restclient/async_client.py
+++ b/python/_restclient/hydrotools/_restclient/async_client.py
@@ -62,6 +62,9 @@ async def backoff(request, n: int = 3):
     for nth in range(n):
         resp = await request()
 
+        if nth == (n - 1):
+            break  # break early on last iteration
+
         if resp.status not in RETRY_STATUS_CODES:
             break  # break, return resp
         # Exponential backoff

--- a/python/_restclient/hydrotools/_restclient/async_client.py
+++ b/python/_restclient/hydrotools/_restclient/async_client.py
@@ -28,6 +28,9 @@ def forge_client_session(init):
 
 with warnings.catch_warnings():
     # Ignore aiohttp.ClientSession Inheritance warning
+    # This is the same approach that aiohttp_client_cache takes to implement their CachedSession object
+    # As noted by aiohttp_client_cache in their implementation:
+    # Since only _request() is overridden, there is minimal chance of breakage, but still possible
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, message="Inheritance class"
     )

--- a/python/_restclient/hydrotools/_restclient/async_helpers.py
+++ b/python/_restclient/hydrotools/_restclient/async_helpers.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+import asyncio
+from typing import Coroutine
+
+
+__all__ = []
+
+
+class AsyncToSerialHelper:
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop = None,
+    ) -> None:
+        self._loop = loop
+
+        # if loop not passed, get running or start new
+        if loop is None:
+            self._loop = asyncio.get_event_loop()
+
+    def _add_to_loop(self, coro: Coroutine):
+        return self._loop.run_until_complete(coro)

--- a/python/_restclient/hydrotools/_restclient/async_helpers.py
+++ b/python/_restclient/hydrotools/_restclient/async_helpers.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import asyncio
 from typing import Callable, Coroutine
 from functools import partial, wraps

--- a/python/_restclient/hydrotools/_restclient/async_helpers.py
+++ b/python/_restclient/hydrotools/_restclient/async_helpers.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 import asyncio
-from typing import Coroutine
+from typing import Callable, Coroutine
+from functools import partial, wraps
 
 
 __all__ = []
@@ -12,11 +13,30 @@ class AsyncToSerialHelper:
         self,
         loop: asyncio.AbstractEventLoop = None,
     ) -> None:
-        self._loop = loop
+        self._loop = loop  # type: asyncio.AbstractEventLoop
 
         # if loop not passed, get running or start new
         if loop is None:
             self._loop = asyncio.get_event_loop()
 
     def _add_to_loop(self, coro: Coroutine):
+        """ Add coro to event loop via run_until_complete """
         return self._loop.run_until_complete(coro)
+
+    def _wrap_func_in_coro(self, func: Callable, *args, **kwargs):
+        """ Create partial func; wrap and call partial in coro; return coro """
+        part = partial(func, *args, **kwargs)
+
+        async def wrap():
+            return part()
+
+        return wrap
+
+    def _wrap_coro_in_callable(self, coro: Coroutine) -> Callable:
+        """ Wrap coro in method (that accepts args, kwargs) which adds coro to event loop. """
+
+        @wraps(coro)
+        def wrap(*args, **kwargs):
+            return self._add_to_loop(coro(*args, **kwargs))
+
+        return wrap

--- a/python/_restclient/hydrotools/_restclient/urllib.py
+++ b/python/_restclient/hydrotools/_restclient/urllib.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import urllib.parse as parse
 from typing import Dict, List, Tuple, Union, TypeVar
 from collections import UserString

--- a/python/_restclient/hydrotools/_restclient/urllib.py
+++ b/python/_restclient/hydrotools/_restclient/urllib.py
@@ -69,7 +69,7 @@ class Url:
 
     def __str__(self) -> str:
         """ unquoted string representation of url """
-        return str(self)
+        return str(self._url.geturl())
 
     def __repr__(self) -> str:
         """ unquoted string representation of url """

--- a/python/_restclient/hydrotools/_restclient/urllib.py
+++ b/python/_restclient/hydrotools/_restclient/urllib.py
@@ -13,7 +13,7 @@ __all__ = ["Url", "Variadic"]
 PRIMITIVE = TypeVar("PRIMITIVE", bool, float, int, str, None)
 
 
-class Url:
+class Url(UserString, str):
     """
     Treat urls analogous to pathlib.Path's treatment of paths.
 
@@ -66,20 +66,7 @@ class Url:
 
         self._validate_construction(self._url)
         self._url = self._clean_parse_result(self._url)
-
-    def __str__(self) -> str:
-        """ unquoted string representation of url """
-        return str(self._url.geturl())
-
-    def __repr__(self) -> str:
-        """ unquoted string representation of url """
-        return repr(self._url.geturl())
-
-    def __eq__(self, o: object) -> bool:
-        return self.url == o
-
-    def __contains__(self, o: object) -> bool:
-        return o in self.url
+        self.data = self._url.geturl()
 
     def __add__(self, b: Dict[str, Union[str, List[str]]]) -> "Url":
         """Add/append query parameters to `Url` object using `+` operator. See `Url.add`

--- a/python/_restclient/hydrotools/_restclient/urllib.py
+++ b/python/_restclient/hydrotools/_restclient/urllib.py
@@ -78,6 +78,9 @@ class Url:
     def __eq__(self, o: object) -> bool:
         return self.url == o
 
+    def __contains__(self, o: object) -> bool:
+        return o in self.url
+
     def __add__(self, b: Dict[str, Union[str, List[str]]]) -> "Url":
         """Add/append query parameters to `Url` object using `+` operator. See `Url.add`
         for further details. Methods are equivalent.

--- a/python/_restclient/hydrotools/_restclient/urllib.py
+++ b/python/_restclient/hydrotools/_restclient/urllib.py
@@ -176,8 +176,10 @@ class Url(UserString, str):
         >>> print(url)
         >>> https://www.test.gov/api
         """
-        path = f"{self._url.path}/{b}"
-        return self._build_parse_result_cast_to_url(self._url, path=path)
+        if isinstance(b, str):
+            path = f"{self._url.path}/{b}"
+            return self._build_parse_result_cast_to_url(self._url, path=path)
+        raise TypeError("Arg is required subclass string")
 
     @property
     def url(self) -> str:

--- a/python/_restclient/hydrotools/_restclient/urllib.py
+++ b/python/_restclient/hydrotools/_restclient/urllib.py
@@ -2,6 +2,7 @@
 
 import urllib.parse as parse
 from typing import Dict, List, Tuple, Union, TypeVar
+from collections import UserString
 import re
 
 # local imports
@@ -248,3 +249,19 @@ class Url:
 
 def _are_properties_set(obj: object, properties: Union[List[str], Tuple[str]]) -> bool:
     return all([getattr(obj, prop, None) for prop in properties])
+
+
+class Variadic(UserString, str):
+    """join list or tuple on some delimeter. The is useful when specifying arguments in
+    a URL that do not conform to the &key=value&key=value2 convention.
+
+    Example:
+        >>> from hydrotools.restclient import ClientSession, Url, Variadic
+        >>> url = Url("https://www.test.gov")
+        >>> url = url + {"this": Variadic(["that", "the", "other"])}
+        >>> print(url.url)
+        >>> https://www.test.gov/?this=that,the,other
+    """
+
+    def __init__(self, values: Union[List, Tuple], *, delimeter: str = ",") -> None:
+        self.data = delimeter.join([str(v) for v in values])

--- a/python/_restclient/hydrotools/_restclient/urllib.py
+++ b/python/_restclient/hydrotools/_restclient/urllib.py
@@ -66,11 +66,11 @@ class Url:
 
     def __str__(self) -> str:
         """ unquoted string representation of url """
-        return repr(self)
+        return str(self)
 
     def __repr__(self) -> str:
         """ unquoted string representation of url """
-        return self._url.geturl()
+        return repr(self._url.geturl())
 
     def __eq__(self, o: object) -> bool:
         return self.url == o
@@ -189,7 +189,7 @@ class Url:
     @property
     def url(self) -> str:
         """ Unquoted string representation of url """
-        return repr(self)
+        return str(self)
 
     @property
     def quote_url(self) -> str:

--- a/python/_restclient/hydrotools/_restclient/urllib.py
+++ b/python/_restclient/hydrotools/_restclient/urllib.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+
+import urllib.parse as parse
+from typing import Dict, List, Tuple, Union, TypeVar
+import re
+
+# local imports
+from ._iterable_nonstring import IterableNonStringLike
+
+PRIMITIVE = TypeVar("PRIMITIVE", bool, float, int, str, None)
+
+
+class Url:
+    """
+    Treat urls analogous to pathlib.Path's treatment of paths.
+
+    Examples:
+        Concatenate urls using the forward slash operator (see equivalent `Url.joinurl`)
+        >>> url = Url("https://www.test.gov") / "api" / "feature"
+        >>> print(url)
+        >>> https://www.test.gov/api/feature
+
+        Append url query using the plus operator (see equivalent `Url.add` method)
+        >>> url = url + {"format": "json", "sites": [1,2,3]}
+        >>> print(url)
+        >>> https://www.test.gov/api/feature?format=json&sites=1&sites=2&sites=3
+
+        Automagically unquote urls
+        >>> o = Url("https://www.test.gov/?quoted=%27args%27")
+        >>> print(o)
+        >>> https://www.test.gov/?quoted='args'
+        >>> # Re-quote the url
+        >>> print(o.quote_url)
+        >>> https://www.test.gov/?quoted=%27args%27
+
+        Supports comparing quoted and unquoted urls
+        >>> o = Url("https://www.test.gov/?quoted=%27args%27")
+        >>> o2 = Url("https://www.test.gov/?quoted='args'")
+        >>> assert o == o2 # True
+
+    Note:
+        Urls are quoted using urllib.parse.quote_plus, where spaces are replaced with
+        `+`s to support building queries. Likewise, urls are unquoted using
+        urllib.parse.unquote_plus to mirror the behavior when unquoting.
+
+        urls are unquoted at construction time for `Url` object comparison sake
+        equivalency and readability.
+
+        url query parameter values passed as either a list or tuple are represented with
+        individual `key=value` pairs each seperated by the `&` (i.e. {"key": ["v_0",
+        "v_1"]} -> key=v_0&key=v_1).
+
+    """
+
+    def __init__(self, url: Union[str, "Url"]) -> None:
+        if isinstance(url, Url):
+            url = url.url
+
+        if not url.startswith("http://") and not url.startswith("https://"):
+            url = f"https://{url}"
+
+        self._url = parse.urlparse(url)
+
+        self._validate_construction(self._url)
+        self._url = self._clean_parse_result(self._url)
+
+    def __str__(self) -> str:
+        """ unquoted string representation of url """
+        return repr(self)
+
+    def __repr__(self) -> str:
+        """ unquoted string representation of url """
+        return self._url.geturl()
+
+    def __eq__(self, o: object) -> bool:
+        return self.url == o
+
+    def __add__(self, b: Dict[str, Union[str, List[str]]]) -> "Url":
+        """Add/append query parameters to `Url` object using `+` operator. See `Url.add`
+        for further details. Methods are equivalent.
+
+        Example
+        -------
+        >>> url = Url("https://www.test.gov") / "api" / "feature"
+        >>> url = url + {"format": "json", "sites": [1,2,3]}
+        >>> print(url)
+        >>> https://www.test.gov/api/feature?format=json&sites=1&sites=2&sites=3
+        """
+        return self.add(b)
+
+    def add(self, b: Dict[str, Union[PRIMITIVE, List[PRIMITIVE]]]) -> "Url":
+        """Add/append query parameters to `Url` object url via a dictionary. Dictionary
+        values are either specified as either a primitive or list of primitives. Url
+        query parameter values passed in list are represented with individual
+        `key=value` pairs each seperated by the `&` (i.e. {"key": ["v_0", "v_1"]} ->
+        key=v_0&key=v_1).
+
+
+        Parameters
+        ----------
+        b : Dict[str, Union[PRIMITIVE, List[PRIMITIVE]]]
+            mapping of query keywords to query values
+
+        Returns
+        -------
+        Url
+            New Url instance including provided query parameters
+
+        Example
+        -------
+        >>> url = Url("https://www.test.gov") / "api" / "feature"
+        >>> url = url.add({"format": "json", "sites": [1,2,3]})
+        >>> # or equivalently
+        >>> url = url + {"format": "json", "sites": [1,2,3]}
+        >>> print(url)
+        >>> https://www.test.gov/api/feature?format=json&sites=1&sites=2&sites=3
+        """
+        query = parse.parse_qs(self._url.query)  # type: dict[list[str]]
+        # compare keys
+        intersect = set(query) & set(b)
+        left_difference = {k: b[k] for k in set(b) - set(query)}
+
+        # put keys from b not in self in self
+        query.update(left_difference)
+
+        # append values from b to keys existing in self
+        for k in intersect:
+            to_insert = b[k] if isinstance(b[k], IterableNonStringLike) else [b[k]]
+            query[k].extend(to_insert)
+
+        # Transform query from dict to string of kwargs
+        query = parse.urlencode(query, doseq=True)
+        return self._build_parse_result_cast_to_url(self._url, query=query)
+
+    def __truediv__(self, b: str) -> "Url":
+        """Append path to `Url` object url.  See `Url.joinurl` for further details.
+        Methods are equivalent.
+
+        Parameters
+        ----------
+        b : str
+            Path appended to url of new `Url` instance
+
+        Returns
+        -------
+        Url
+            New Url instance with appended path, `b`.
+
+        Example
+        -------
+        >>> url = Url("https://www.test.gov")
+        >>> url = url / "api"
+        >>> print(url)
+        >>> https://www.test.gov/api
+        """
+        return self.joinurl(b)
+
+    def joinurl(self, b: str) -> "Url":
+        """Append path to `Url` url. Erronenous `/`s are automatically removed. A single
+        trailing `/` is respected if desired but will not be included if not specified.
+
+        Urls can also be joined using the `/` opporator. This is equivalent to calling
+        the `Url.joinurl` method. As such, it is recommended to use the more idiomatic
+        `/` opporator.
+
+
+        Parameters
+        ----------
+        b : str
+            url path to append
+
+        Returns
+        -------
+        Url
+            New Url instance with appended path, `b`.
+
+        Example
+        -------
+        >>> url = Url("https://www.test.gov")
+        >>> url.joinurl("api")
+        >>> # or equivalently
+        >>> url = url / "api"
+        >>> print(url)
+        >>> https://www.test.gov/api
+        """
+        path = f"{self._url.path}/{b}"
+        return self._build_parse_result_cast_to_url(self._url, path=path)
+
+    @property
+    def url(self) -> str:
+        """ Unquoted string representation of url """
+        return repr(self)
+
+    @property
+    def quote_url(self) -> str:
+        """Quoted string representation of url. Urls quoted using
+        urllib.parse.quote_plus."""
+        # serialized query from str/encoded to dict
+        query = parse.parse_qs(self._url.query)  # type: dict[str, list[str]]
+        # Note: list items treated as -> item=1&item=2 not item=%5B1%2C+2%5D
+        query = parse.urlencode(query, doseq=True)
+        return self._build_parse_result(self._url, query=query).geturl()
+
+    @staticmethod
+    def _validate_construction(url: parse.ParseResult):
+        # ensure `netloc` property is set
+        required_properties = ["netloc"]
+        required_set = _are_properties_set(url, required_properties)
+
+        # Fail fast
+        if not required_set:
+            raise ValueError(f"invalid url, requires {required_properties}.")
+
+    @staticmethod
+    def _clean_parse_result(url: parse.ParseResult) -> parse.ParseResult:
+        # remove repeated occurrence of /
+        path = re.sub("//+", "/", url.path)
+        # unquote query args for readability
+        query = parse.unquote_plus(url.query)
+
+        return Url._build_parse_result(url, path=path, query=query)
+
+    @staticmethod
+    def _build_parse_result(
+        url: parse.ParseResult,
+        *,
+        scheme=None,
+        netloc=None,
+        path=None,
+        params=None,
+        query=None,
+        fragment=None,
+    ) -> parse.ParseResult:
+        return parse.ParseResult(
+            scheme=scheme if scheme is not None else url.scheme,
+            netloc=netloc if netloc is not None else url.netloc,
+            path=path if path is not None else url.path,
+            params=params if params is not None else url.params,
+            query=query if query is not None else url.query,
+            fragment=fragment if fragment is not None else url.fragment,
+        )
+
+    @staticmethod
+    def _build_parse_result_cast_to_url(url: parse.ParseResult, **kwargs) -> "Url":
+        result = Url._build_parse_result(url, **kwargs)
+        return Url(result.geturl())
+
+
+def _are_properties_set(obj: object, properties: Union[List[str], Tuple[str]]) -> bool:
+    return all([getattr(obj, prop, None) for prop in properties])

--- a/python/_restclient/hydrotools/_restclient/urllib.py
+++ b/python/_restclient/hydrotools/_restclient/urllib.py
@@ -257,3 +257,12 @@ class Variadic(UserString, str):
 
     def __init__(self, values: Union[List, Tuple], *, delimeter: str = ",") -> None:
         self.data = delimeter.join([str(v) for v in values])
+
+    def encode(self, encoding: str = ..., errors: str = ...) -> bytes:
+        kwargs = {}
+        if encoding is not Ellipsis:
+            kwargs["encoding"] = encoding
+        if errors is not Ellipsis:
+            kwargs["errors"] = errors
+
+        return self.data.encode(**kwargs)

--- a/python/_restclient/hydrotools/_restclient/urllib.py
+++ b/python/_restclient/hydrotools/_restclient/urllib.py
@@ -8,6 +8,8 @@ import re
 # local imports
 from ._iterable_nonstring import IterableNonStringLike
 
+__all__ = ["Url", "Variadic"]
+
 PRIMITIVE = TypeVar("PRIMITIVE", bool, float, int, str, None)
 
 

--- a/python/_restclient/hydrotools/_restclient/utilities.py
+++ b/python/_restclient/hydrotools/_restclient/utilities.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 from copy import deepcopy
 from dataclasses import dataclass
 from typing import Callable, Hashable, Iterable, List, Union

--- a/python/_restclient/setup.py
+++ b/python/_restclient/setup.py
@@ -20,9 +20,7 @@ AUTHOR = "Austin Raney"
 AUTHOR_EMAIL = "arthur.raney@noaa.gov"
 
 # Short sub-package description
-DESCRIPTION = (
-    "Utilities adept for quickly and succinctly writing REST api client libraries."
-)
+DESCRIPTION = "General REST api client with built in request caching and retries."
 
 # Package dependency requirements
 REQUIREMENTS = ["aiohttp", "aiohttp_client_cache", "python-forge", "aiosqlite"]

--- a/python/_restclient/setup.py
+++ b/python/_restclient/setup.py
@@ -13,17 +13,21 @@ SUBPACKAGE_NAME = "_restclient"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "2.1.0-alpha.0"
+VERSION = "3.0.0"
 
 # Package author information
 AUTHOR = "Austin Raney"
 AUTHOR_EMAIL = "arthur.raney@noaa.gov"
 
 # Short sub-package description
-DESCRIPTION = "Abstract REST api client with built in request caching and retries"
+DESCRIPTION = (
+    "Utilities adept for quickly and succinctly writing REST api client libraries."
+)
 
 # Package dependency requirements
-REQUIREMENTS = ["requests", "requests_cache"]
+REQUIREMENTS = ["aiohttp", "aiohttp_client_cache", "python-forge", "aiosqlite"]
+DEVELOPMENT_REQUIREMENTS = ["pytest", "pytest-aiohttp"]
+
 
 setup(
     name=SUBPACKAGE_SLUG,
@@ -35,4 +39,5 @@ setup(
     namespace_packages=[NAMESPACE_PACKAGE_NAME],
     packages=find_namespace_packages(include=[f"{NAMESPACE_PACKAGE_NAME}.*"]),
     install_requires=REQUIREMENTS,
+    extras_require={"develop": DEVELOPMENT_REQUIREMENTS},
 )

--- a/python/_restclient/tests/test_urllib.py
+++ b/python/_restclient/tests/test_urllib.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+import pytest
+
+from hydrotools._restclient.urllib import Url
+
+
+@pytest.mark.parametrize("url", ["http://www.fake.gov", "https://www.fake.gov"])
+def test_construction(url):
+    inst = Url(url)
+    assert repr(inst) == url
+    assert inst.url == url
+    assert str(inst) == url
+
+
+def test_failed_construction():
+    """ should fail if netloc not passed """
+    url = "https://"
+    with pytest.raises(ValueError):
+        Url(url)
+
+
+def test_implict_https_scheme():
+    """ https scheme assumed if none passed at construction """
+    url = "www.test.gov"
+    inst = Url(url)
+    assert repr(inst) == f"https://{url}"
+
+
+def test_joinurl():
+    url = "https://www.test.gov"
+    path = "api"
+    inst = Url(url)
+    inst1 = inst.joinurl(path)
+    inst2 = inst / path
+
+    assert repr(inst1) == f"{url}/{path}"
+    assert repr(inst2) == f"{url}/{path}"
+    assert isinstance(inst1, Url)
+    assert isinstance(inst2, Url)
+
+
+def test_repeated_joinurl_with_truedivide():
+    url = "https://www.test.gov"
+    path = "api"
+    inst = Url(url)
+
+    inst1 = inst / path / path
+    inst1
+
+    assert inst1 == f"{url}/{path}/{path}"
+
+
+def test_add_query():
+    url = "https://www.test.gov"
+    query = {"this": "that"}
+    inst = Url(url)
+
+    inst1 = inst.add(query)
+    inst2 = inst + query
+    inst3 = inst2 + query
+
+    assert inst1 == f"{url}?this=that"
+    assert inst2 == f"{url}?this=that"
+    assert inst3 == f"{url}?this=that&this=that"
+
+    query2 = {"n": [1, "2", 3]}
+    inst4 = inst2 + query2
+    assert inst4 == f"{url}?this=that&n=1&n=2&n=3"
+
+
+def test_equivalency_between_quoted_url_and_unquoted_url():
+    url = "https://www.test.gov/?this='12'"
+    inst = Url(url)
+
+    url2 = "https://www.test.gov/?this=%2712%27"
+    inst2 = Url(url2)
+    assert inst == inst2


### PR DESCRIPTION
Main features:

- `RestClient`: a class which offers asynchronous performance via a convenient serial wrapper, sqlite database GET request caching, GET request backoff, batch GET requests, and flexible url argument encoding.

- `Url`: Treat urls like to `pathlib.Path`s. Supports appending paths with `/` and appending url query parameters with `+`.

- `ClientSession`: Extension of [`aiohttp_client_cache`](https://github.com/JWCook/aiohttp-client-cache) that adds exponential backoff.

- `Variadic`: Join list or tuple of objects on some delimiter. Useful when query parameters utilize a non-`key=value&key=value2` pattern.

- `Alias` and `AliasGroup`: Immutable utility classes that simplify common API library development patterns (i.e. separation of backend uris from front end interfaces).

Distantly related to:  #70, #50, #14

The main feature of interest is the `RestClient` and its `mget` method. Basically you pass in a list of `urls` and it using `aiohttp` to get all of the requests using async. 


## Additions

- `Url`: Treat urls like to `pathlib.Path`s. Supports appending paths with `/` and appending url query parameters with `+`.

- `ClientSession`: Extension of [`aiohttp_client_cache`](https://github.com/JWCook/aiohttp-client-cache) that adds exponential backoff.

- `Variadic`: Join list or tuple of objects on some delimiter. Useful when query parameters utilize a non-`key=value&key=value2` pattern.

## Removals

- 

## Changes

- `RestClient`: a class which offers asynchronous performance via a convenient serial wrapper, sqlite database GET request caching, GET request backoff, batch GET requests, and flexible url argument encoding.
- RestClient parameters changed (breaking).


## Notes

- This functionality will be ported to `nwis_client` and `gcp_client` in future PRs.

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
