### PR TITLE
Move development deps concern from namespace to subpackage concern

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,9 @@ DESCRIPTION = "{{ SHORT_DESCRIPTION }}"
 # Package dependency requirements
 REQUIREMENTS = []
 
+# Development requirements
+DEVELOPMENT_REQUIREMENTS = ["pytest"]
+
 setup(
     name=SUBPACKAGE_SLUG,
     version=VERSION,
@@ -157,6 +160,7 @@ setup(
         include=[f"{NAMESPACE_PACKAGE_NAME}.*"]
     ),
     install_requires=REQUIREMENTS,
+    extras_require={"develop": DEVELOPMENT_REQUIREMENTS},
 )
 ```
 

--- a/python/events/setup.py
+++ b/python/events/setup.py
@@ -32,6 +32,9 @@ REQUIREMENTS = [
     "pandas",
 ]
 
+# Development requirements
+DEVELOPMENT_REQUIREMENTS = ["pytest"]
+
 setup(
     name=SUBPACKAGE_SLUG,
     version=VERSION,
@@ -53,4 +56,5 @@ setup(
     namespace_packages=[NAMESPACE_PACKAGE_NAME],
     packages=find_namespace_packages(include=[f"{NAMESPACE_PACKAGE_NAME}.*"]),
     install_requires=REQUIREMENTS,
+    extras_require={"develop": DEVELOPMENT_REQUIREMENTS},
 )

--- a/python/gcp_client/setup.py
+++ b/python/gcp_client/setup.py
@@ -37,6 +37,9 @@ REQUIREMENTS = [
     "numpy>=1.20.0"
     ]
 
+# Development requirements
+DEVELOPMENT_REQUIREMENTS = ["pytest"]
+
 setup(
     name=SUBPACKAGE_SLUG,
     version=VERSION,
@@ -66,4 +69,5 @@ setup(
         ]
     },
     install_requires=REQUIREMENTS,
+    extras_require={"develop": DEVELOPMENT_REQUIREMENTS},
 )

--- a/python/metrics/setup.py
+++ b/python/metrics/setup.py
@@ -33,6 +33,9 @@ REQUIREMENTS = [
     "numpy>=1.20.0"
 ]
 
+# Development requirements
+DEVELOPMENT_REQUIREMENTS = ["pytest"]
+
 setup(
     name=SUBPACKAGE_SLUG,
     version=VERSION,
@@ -54,4 +57,5 @@ setup(
     namespace_packages=[NAMESPACE_PACKAGE_NAME],
     packages=find_namespace_packages(include=[f"{NAMESPACE_PACKAGE_NAME}.*"]),
     install_requires=REQUIREMENTS,
+    extras_require={"develop": DEVELOPMENT_REQUIREMENTS},
 )

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,6 @@ DESCRIPTION = (
 LONG_DESCRIPTION = Path("README.md").read_text()
 LICENSE = Path("LICENSE").read_text()
 
-# Development requirements
-DEVELOPMENT_REQUIREMENTS = ["pytest"]
-
 
 def get_subpackage_names() -> List[str]:
     # This assumes that each subpackage has a setup.py and is located under python/

--- a/setup.py
+++ b/setup.py
@@ -87,9 +87,7 @@ def build_subpackage_mapping() -> Dict[str, str]:
     return subpackage_mapping
 
 
-def install_subpackages(
-    sources: dict,
-) -> None:
+def install_subpackages(sources: dict, develop_flag: bool = False) -> None:
     """Install all subpackages in a namespace package
 
     Parameters
@@ -104,6 +102,8 @@ def install_subpackages(
     for k, v in sources.items():
         try:
             subpackage_dir = str(ROOT_DIR / v)
+            if develop_flag:
+                subpackage_dir = f"{subpackage_dir}[develop]"
             subprocess.check_call(
                 [
                     sys.executable,
@@ -125,12 +125,7 @@ SUBPACKAGES = build_subpackage_mapping()
 # Development installation
 class Develop(develop):
     def run(self):
-        install_subpackages(SUBPACKAGES)
-        # Install development requirements
-        for dev_requirement in DEVELOPMENT_REQUIREMENTS:
-            subprocess.check_call(
-                [sys.executable, "-m", "pip", "install", dev_requirement]
-            )
+        install_subpackages(SUBPACKAGES, develop_flag=True)
 
 
 setup(
@@ -152,7 +147,6 @@ setup(
     url=URL,
     license=LICENSE,
     install_requires=REQUIREMENTS,
-    extras_require={"test": DEVELOPMENT_REQUIREMENTS},
     python_requires=">=3.7",
     cmdclass={"develop": Develop},
 )


### PR DESCRIPTION
Development deps like `pytest` have been moved to subpackage `setup.py`. To install development requirements for a specific subpackage you now do: `pip install -e hydrotools.subpackage[develop]`. The behavior for installing the entire subpackage has not changed, it is still `python setup.py develop`.

closes #79

## Additions

-

## Removals

-

## Changes

- Development requirements moved from namespace package level to subpackage `setup.py` level. Now uses `pip install -e hydrotools.subpackage[develop]` semantics. Installation for namespace package in develop mode has not changed. 

## Notes

- I did not include this in `_restclient` or `nwis_client`. This will be introduced for those subpackages in #86 


## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
