### PR TITLE
Pre-release nwis_client require  _restclient 3.0.0 and gh-actions install _restclient explicitly

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -22,6 +22,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip pytest pytest-aiohttp coverage coverage-badge
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        # see #91 for reasoning behind explicit install of _restclient
+        pip install -e "python/_restclient[develop]"
         python setup.py develop
     - name: Run all unittests 
       run: |

--- a/python/nwis_client/setup.py
+++ b/python/nwis_client/setup.py
@@ -28,7 +28,7 @@ DESCRIPTION = (
 REQUIREMENTS = [
     "pandas",
     "numpy",
-    "hydrotools._restclient",
+    "hydrotools._restclient>=3.0.0",
     "aiohttp"
 ]
 

--- a/python/nwis_client/tests/test_nwis.py
+++ b/python/nwis_client/tests/test_nwis.py
@@ -103,7 +103,6 @@ def test_get_headers(setup_iv):
 
 
 def request_status_setter(status: int = 404):
-    import requests
     from functools import partial
 
     requests_testable_attributes = {"status_code": status}
@@ -159,17 +158,17 @@ def test_get_raw_with_mock(setup_iv, monkeypatch):
 def test_handle_response(setup_iv, monkeypatch):
     import json
     from pathlib import Path
-    import requests
+    import aiohttp
 
     def mock_json(*args, **kwargs):
         return json.loads(
             (Path(__file__).resolve().parent / "nwis_test_data.json").read_text()
         )
 
-    monkeypatch.setattr(requests.Response, "json", mock_json)
+    monkeypatch.setattr(aiohttp.ClientResponse, "json", mock_json)
 
     assert (
-        setup_iv._handle_response(requests.Response)[0]["usgs_site_code"] == "01646500"
+        setup_iv._handle_response(aiohttp.ClientResponse)[0]["usgs_site_code"] == "01646500"
     )
 
 


### PR DESCRIPTION
Add `_restclient` version requirement for `nwis_client`. Now requires `3.0.0`

The Run Unit Tests `gh-action` now installs `_restclient` explicitly prior to installing the namespace package. See below for context.

## Notes

- This is a pre-release PR before the `restclient_transition` branch is merged into `main`


## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
