### PR TITLE
fix gh-pages deployment. related to #94

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -22,7 +22,7 @@ jobs:
         python -m pip install --upgrade pip Sphinx furo
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install -e "python/_restclient[develop]"
-        python -m pip install -e .
+        python setup.py develop
     - name: Build Sphinx documentation
       run: |
         cd docs/


### PR DESCRIPTION
`pip install -e .` causing failure b.c. installing _restclient twice.
Related to #94 

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
