### PR TITLE
Add GitHub Url to setup.py

### DIFF
--- a/python/_restclient/setup.py
+++ b/python/_restclient/setup.py
@@ -34,6 +34,8 @@ setup(
     author_email=AUTHOR_EMAIL,
     classifiers=[],
     description=DESCRIPTION,
+    url="https://www.github.com/NOAA-OWP/hydrotools",
+    license="USDOC",
     namespace_packages=[NAMESPACE_PACKAGE_NAME],
     packages=find_namespace_packages(include=[f"{NAMESPACE_PACKAGE_NAME}.*"]),
     install_requires=REQUIREMENTS,

--- a/python/nwis_client/setup.py
+++ b/python/nwis_client/setup.py
@@ -42,6 +42,8 @@ setup(
     author_email=AUTHOR_EMAIL,
     classifiers=[],
     description=DESCRIPTION,
+    url="https://www.github.com/NOAA-OWP/hydrotools",
+    license="USDOC",
     namespace_packages=[NAMESPACE_PACKAGE_NAME],
     packages=find_namespace_packages(include=[f"{NAMESPACE_PACKAGE_NAME}.*"]),
     install_requires=REQUIREMENTS,

--- a/setup.py
+++ b/setup.py
@@ -136,9 +136,12 @@ setup(
     maintainer=MAINTAINER,
     maintainer_email=MAINTAINER_EMAIL,
     classifiers=[
-        "Private :: Do Not Upload to pypi server",
+        "Intended Audience :: Education",
+        "Intended Audience :: Science/Research",
+        "License :: Free To Use But Restricted",
         "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
+        "Topic :: Scientific/Engineering :: Hydrology"
+        "Programming Language :: Python :: 3",
         "Operating System :: OS Independent",
     ],
     description=DESCRIPTION,


### PR DESCRIPTION
Add hydrotools github url to `_restclient` and `nwis_client` `setup.py` files plus update listed license.

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
