### PR TITLE
Fix #99: "RuntimeError: This event loop is already running" in colab and notebook

### DIFF
--- a/python/_restclient/hydrotools/_restclient/_restclient.py
+++ b/python/_restclient/hydrotools/_restclient/_restclient.py
@@ -288,6 +288,11 @@ class RestClient(AsyncToSerialHelper):
 
     def close(self) -> None:
         """ Release aiohttp.ClientSession """
+        # Session never instantiated, thus cannot be closed
+        session = getattr(self, "_session", None)
+        if session is None:
+            return
+
         if not self._session.closed:
             if not self._loop.is_closed():
                 self._add_to_loop(self._session.close())

--- a/python/_restclient/hydrotools/_restclient/async_helpers.py
+++ b/python/_restclient/hydrotools/_restclient/async_helpers.py
@@ -19,7 +19,24 @@ class AsyncToSerialHelper:
 
     def _add_to_loop(self, coro: Coroutine):
         """ Add coro to event loop via run_until_complete """
-        return self._loop.run_until_complete(coro)
+        try:
+            return self._loop.run_until_complete(coro)
+
+        except RuntimeError as e:
+            try:
+                # `RuntimeError: This event loop is already running` thrown by jupyter notebook
+                # See hydrotools #99 for context and notebook #3397 for detail
+                import nest_asyncio
+
+                nest_asyncio.apply()
+
+                return self._loop.run_until_complete(coro)
+            except ModuleNotFoundError:
+                error_message = (
+                    "nest_asycnio package not found. Install using `pip install nest_asycnio`.\n"
+                    "See https://github.com/NOAA-OWP/hydrotools/issues/99 for more detail."
+                )
+                raise ModuleNotFoundError(error_message) from e
 
     def _wrap_func_in_coro(self, func: Callable, *args, **kwargs):
         """ Create partial func; wrap and call partial in coro; return coro """

--- a/python/_restclient/setup.py
+++ b/python/_restclient/setup.py
@@ -14,7 +14,7 @@ SUBPACKAGE_NAME = "_restclient"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "3.0.1"
+VERSION = "3.0.2"
 
 # Package author information
 AUTHOR = "Austin Raney"

--- a/python/_restclient/tests/test_restclient.py
+++ b/python/_restclient/tests/test_restclient.py
@@ -150,3 +150,23 @@ def test_build_url(loop):
 
         assert client.build_url(base_url) == base_url
         assert client.build_url(base_url, query_params) == f"{base_url}?key=value"
+
+
+def test_restclient_nest_asyncio_ModuleNotFoundError(loop):
+    """Test for #99"""
+    import asyncio
+    import warnings
+
+    async def test():
+        await asyncio.sleep(0.01)
+
+        with warnings.catch_warnings():
+            # ignore coroutine not awaited warning for output sake.
+            # This is not the purpose of this test
+            warnings.simplefilter("ignore", category=RuntimeWarning)
+            with pytest.raises(ModuleNotFoundError):
+                # implicitly verify that `nest_asyncio` is not installed
+                # this test will need to change if `nest_asyncio` becomes a requirement
+                RestClient(enable_cache=False)
+
+    loop.run_until_complete(test())


### PR DESCRIPTION
Fixes #99

## Changes

- If event loop is already running and `RestClient` is instantiated, try to `import nest_asyncio` and patch with `nest_asyncio.apply()`. Raise `ModuleNotFoundError` if `nest_asyncio` not installed.

## Testing

1. Test added to verify `ModuleNotFoundError` is raised.

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
