### PR TITLE
gcp_client: Do not use string categories for NWM feature IDs

### DIFF
--- a/python/gcp_client/hydrotools/gcp_client/gcp.py
+++ b/python/gcp_client/hydrotools/gcp_client/gcp.py
@@ -101,7 +101,7 @@ class NWMDataService:
             for MAP_FILE in _FEATURE_ID_TO_USGS_SITE_MAP_FILES:
                 dfs.append(pd.read_csv(
                 MAP_FILE,
-                dtype={"nwm_feature_id": int, "usgs_site_code": str},
+                dtype={"nwm_feature_id": str, "usgs_site_code": str},
                 comment='#'
             ).set_index('nwm_feature_id')[['usgs_site_code']])
             self.crosswalk = pd.concat(dfs)

--- a/python/gcp_client/hydrotools/gcp_client/gcp.py
+++ b/python/gcp_client/hydrotools/gcp_client/gcp.py
@@ -101,7 +101,7 @@ class NWMDataService:
             for MAP_FILE in _FEATURE_ID_TO_USGS_SITE_MAP_FILES:
                 dfs.append(pd.read_csv(
                 MAP_FILE,
-                dtype={"nwm_feature_id": str, "usgs_site_code": str},
+                dtype={"nwm_feature_id": int, "usgs_site_code": str},
                 comment='#'
             ).set_index('nwm_feature_id')[['usgs_site_code']])
             self.crosswalk = pd.concat(dfs)

--- a/python/gcp_client/hydrotools/gcp_client/gcp.py
+++ b/python/gcp_client/hydrotools/gcp_client/gcp.py
@@ -287,9 +287,6 @@ class NWMDataService:
             'feature_id': 'nwm_feature_id'
         })
 
-        # Categorize feature id
-        df['nwm_feature_id'] = df['nwm_feature_id'].astype(str).astype(dtype="category")
-        
         # Downcast floats
         df_float = df.select_dtypes(include=["float"])
         converted_float = df_float.apply(pd.to_numeric, downcast="float")
@@ -351,20 +348,22 @@ class NWMDataService:
         df = df.rename(columns={'streamflow': 'value'})
 
         # Reformat crosswalk
-        xwalk = self.crosswalk.reset_index()
-
+        xwalk = self.crosswalk
+        
         # Additional columns
         xwalk['configuration'] = configuration
         xwalk['measurement_unit'] = 'm3/s'
         xwalk['variable_name'] = 'streamflow'
 
-        # Categorize
-        xwalk = xwalk.astype(str).astype('category')
-        xwalk = xwalk.set_index('nwm_feature_id')
-
         # Apply crosswalk metadata
         for col in xwalk:
             df[col] = df['nwm_feature_id'].map(xwalk[col])
+
+        # Categorize
+        df['configuration'] = df['configuration'].astype("category")
+        df['measurement_unit'] = df['measurement_unit'].astype("category")
+        df['variable_name'] = df['variable_name'].astype("category")
+        df['usgs_site_code'] = df['usgs_site_code'].astype("category")
 
         # Sort values
         df = df.sort_values(

--- a/python/gcp_client/setup.py
+++ b/python/gcp_client/setup.py
@@ -14,7 +14,7 @@ SUBPACKAGE_NAME = "gcp_client"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "3.0.0"
+VERSION = "4.0.0"
 
 # Package author information
 AUTHOR = "Jason Regina"

--- a/python/gcp_client/tests/test_gcp.py
+++ b/python/gcp_client/tests/test_gcp.py
@@ -27,202 +27,206 @@ def test_crosswalk(setup_gcp):
 
     assert setup_gcp.crosswalk.loc[6186112, "usgs_site_code"] == "01360640"
 
-# def test_cache_path(setup_gcp):
-#     assert str(setup_gcp.cache_path) == 'gcp_client.h5'
+def test_cache_path(setup_gcp):
+    assert str(setup_gcp.cache_path) == 'gcp_client.h5'
 
-#     setup_gcp.cache_path = 'custom_cache.h5'
-#     assert str(setup_gcp.cache_path) == 'custom_cache.h5'
+    setup_gcp.cache_path = 'custom_cache.h5'
+    assert str(setup_gcp.cache_path) == 'custom_cache.h5'
 
-# def test_cache_group(setup_gcp):
-#     assert str(setup_gcp.cache_group) == 'gcp_client'
+def test_cache_group(setup_gcp):
+    assert str(setup_gcp.cache_group) == 'gcp_client'
 
-#     setup_gcp.cache_group = 'simulations'
-#     assert str(setup_gcp.cache_group) == 'simulations'
+    setup_gcp.cache_group = 'simulations'
+    assert str(setup_gcp.cache_group) == 'simulations'
 
-# @pytest.mark.slow
-# def test_list_blobs(setup_gcp):
-#     blob_list = setup_gcp.list_blobs(
-#         configuration="short_range",
-#         reference_time="20210101T01Z"
-#     )
+@pytest.mark.slow
+def test_list_blobs(setup_gcp):
+    blob_list = setup_gcp.list_blobs(
+        configuration="short_range",
+        reference_time="20210101T01Z"
+    )
 
-#     assert len(blob_list) == 18
+    assert len(blob_list) == 18
 
-# @pytest.mark.slow
-# def test_get_blob(setup_gcp):
-#     blob_name = "nwm.20210101/short_range/nwm.t01z.short_range.channel_rt.f001.conus.nc"
-#     blob_data = setup_gcp.get_blob(blob_name)
-#     assert type(blob_data) == bytes
+@pytest.mark.slow
+def test_get_blob(setup_gcp):
+    blob_name = "nwm.20210101/short_range/nwm.t01z.short_range.channel_rt.f001.conus.nc"
+    blob_data = setup_gcp.get_blob(blob_name)
+    assert type(blob_data) == bytes
 
-# @pytest.mark.slow
-# def test_get_Dataset(setup_gcp):
-#     blob_name = "nwm.20210101/short_range/nwm.t01z.short_range.channel_rt.f001.conus.nc"
+@pytest.mark.slow
+def test_get_Dataset(setup_gcp):
+    blob_name = "nwm.20210101/short_range/nwm.t01z.short_range.channel_rt.f001.conus.nc"
     
-#     # Test default filter
-#     ds = setup_gcp.get_Dataset(blob_name)
-#     assert ds.feature_id.size > 4000
-#     assert ds.feature_id.size < 8000
+    # Test default filter
+    ds = setup_gcp.get_Dataset(blob_name)
+    assert ds.feature_id.size > 4000
+    assert ds.feature_id.size < 8000
 
-#     # Test filter with list
-#     ds = setup_gcp.get_Dataset(blob_name, 
-#         feature_id_filter=[101, 179])
-#     assert ds.feature_id.size == 2
+    # Test filter with list
+    ds = setup_gcp.get_Dataset(blob_name, 
+        feature_id_filter=[101, 179])
+    assert ds.feature_id.size == 2
 
-#     # Test filter with numpy.array
-#     ds = setup_gcp.get_Dataset(blob_name, 
-#         feature_id_filter=np.asarray([101, 179]))
-#     assert ds.feature_id.size == 2
+    # Test filter with numpy.array
+    ds = setup_gcp.get_Dataset(blob_name, 
+        feature_id_filter=np.asarray([101, 179]))
+    assert ds.feature_id.size == 2
 
-#     # Test filter with pandas.Series
-#     features = pd.Series(data=[101, 179])
-#     ds = setup_gcp.get_Dataset(blob_name, 
-#         feature_id_filter=features)
-#     assert ds.feature_id.size == 2
+    # Test filter with pandas.Series
+    features = pd.Series(data=[101, 179])
+    ds = setup_gcp.get_Dataset(blob_name, 
+        feature_id_filter=features)
+    assert ds.feature_id.size == 2
 
-#     # Test no filter
-#     ds = setup_gcp.get_Dataset(blob_name, 
-#         feature_id_filter=False)
-#     assert ds.feature_id.size > 8000
+    # Test no filter
+    ds = setup_gcp.get_Dataset(blob_name, 
+        feature_id_filter=False)
+    assert ds.feature_id.size > 8000
 
-# @pytest.mark.slow
-# def test_get_DataFrame(setup_gcp):
-#     blob_name = "nwm.20210101/short_range/nwm.t01z.short_range.channel_rt.f001.conus.nc"
+@pytest.mark.slow
+def test_get_DataFrame(setup_gcp):
+    blob_name = "nwm.20210101/short_range/nwm.t01z.short_range.channel_rt.f001.conus.nc"
     
-#     # Test default
-#     df = setup_gcp.get_DataFrame(blob_name)
-#     assert len(df.columns) == 4
+    # Test default
+    df = setup_gcp.get_DataFrame(blob_name)
+    assert len(df.columns) == 4
 
-#     # Test all variables
-#     df = setup_gcp.get_DataFrame(blob_name, streamflow_only=False)
-#     assert len(df.columns) > 4
+    # Test all variables
+    df = setup_gcp.get_DataFrame(blob_name, streamflow_only=False)
+    assert len(df.columns) > 4
 
-# @pytest.mark.slow
-# def test_get_cycle(setup_gcp):
-#     # Test ANA
-#     df = setup_gcp.get_cycle(
-#         configuration="analysis_assim",
-#         reference_time="20210101T01Z"
-#     )
-#     assert df['value_time'].unique().size == 3
+@pytest.mark.slow
+def test_get_cycle(setup_gcp):
+    # Test ANA
+    df = setup_gcp.get_cycle(
+        configuration="analysis_assim",
+        reference_time="20210101T01Z"
+    )
+    assert df['value_time'].unique().size == 3
 
-# @pytest.mark.slow
-# def test_cache_disable(setup_gcp):
-#     setup_gcp.cache_path = 'disabled_cache.h5'
+    # Test mapping
+    df = df[df["usgs_site_code"] == "01360640"]
+    assert df["nwm_feature_id"].iloc[0] == 6186112
 
-#     # Test ANA
-#     df = setup_gcp.get(
-#         configuration="analysis_assim",
-#         reference_time="20210101T01Z",
-#         cache_data=False
-#     )
-#     assert df['value_time'].unique().size == 3
-#     assert not setup_gcp.cache_path.exists()
+@pytest.mark.slow
+def test_cache_disable(setup_gcp):
+    setup_gcp.cache_path = 'disabled_cache.h5'
 
-# @pytest.mark.slow
-# def test_cache_key(setup_gcp):
-#     # Test ANA
-#     df1 = setup_gcp.get(
-#         configuration="analysis_assim",
-#         reference_time="20210101T02Z",
-#         cache_data=True
-#     )
-#     first = df1['value_time'].unique().size
+    # Test ANA
+    df = setup_gcp.get(
+        configuration="analysis_assim",
+        reference_time="20210101T01Z",
+        cache_data=False
+    )
+    assert df['value_time'].unique().size == 3
+    assert not setup_gcp.cache_path.exists()
 
-#     with pd.HDFStore(setup_gcp.cache_path) as store:
-#         df2 = store[f"/{setup_gcp.cache_group}/analysis_assim/DT20210101T02Z"]
-#         second = df2['value_time'].unique().size
-#     assert first == second
+@pytest.mark.slow
+def test_cache_key(setup_gcp):
+    # Test ANA
+    df1 = setup_gcp.get(
+        configuration="analysis_assim",
+        reference_time="20210101T02Z",
+        cache_data=True
+    )
+    first = df1['value_time'].unique().size
 
-# @pytest.mark.slow
-# def test_get(setup_gcp):
-#     # Test ANA
-#     df = setup_gcp.get(
-#         configuration="analysis_assim",
-#         reference_time="20210101T01Z"
-#     )
-#     assert df['value_time'].unique().size == 3
+    with pd.HDFStore(setup_gcp.cache_path) as store:
+        df2 = store[f"/{setup_gcp.cache_group}/analysis_assim/DT20210101T02Z"]
+        second = df2['value_time'].unique().size
+    assert first == second
 
-#     # Test Ext. ANA
-#     df = setup_gcp.get(
-#         configuration="analysis_assim_extend",
-#         reference_time="20210101T16Z"
-#     )
-#     assert df['value_time'].unique().size == 28
+@pytest.mark.slow
+def test_get(setup_gcp):
+    # Test ANA
+    df = setup_gcp.get(
+        configuration="analysis_assim",
+        reference_time="20210101T01Z"
+    )
+    assert df['value_time'].unique().size == 3
 
-#     # Test short range
-#     df = setup_gcp.get(
-#         configuration="short_range",
-#         reference_time="20210101T01Z"
-#     )
-#     assert df['value_time'].unique().size == 18
+    # Test Ext. ANA
+    df = setup_gcp.get(
+        configuration="analysis_assim_extend",
+        reference_time="20210101T16Z"
+    )
+    assert df['value_time'].unique().size == 28
 
-#     # Test medium range
-#     df = setup_gcp.get(
-#         configuration="medium_range_mem1",
-#         reference_time="20210101T06Z"
-#     )
-#     assert df['value_time'].unique().size == 80
+    # Test short range
+    df = setup_gcp.get(
+        configuration="short_range",
+        reference_time="20210101T01Z"
+    )
+    assert df['value_time'].unique().size == 18
 
-#     # Test long range
-#     df = setup_gcp.get(
-#         configuration="long_range_mem1",
-#         reference_time="20210101T06Z"
-#     )
-#     assert df['value_time'].unique().size == 120
+    # Test medium range
+    df = setup_gcp.get(
+        configuration="medium_range_mem1",
+        reference_time="20210101T06Z"
+    )
+    assert df['value_time'].unique().size == 80
 
-#     # Test Hawaii ANA
-#     df = setup_gcp.get(
-#         configuration="analysis_assim_hawaii",
-#         reference_time="20210101T01Z"
-#     )
-#     assert df['value_time'].unique().size == 3
+    # Test long range
+    df = setup_gcp.get(
+        configuration="long_range_mem1",
+        reference_time="20210101T06Z"
+    )
+    assert df['value_time'].unique().size == 120
 
-#     # Test Hawaii Short Range
-#     df = setup_gcp.get(
-#         configuration="short_range_hawaii",
-#         reference_time="20210101T00Z"
-#     )
-#     assert df['value_time'].unique().size == 60
+    # Test Hawaii ANA
+    df = setup_gcp.get(
+        configuration="analysis_assim_hawaii",
+        reference_time="20210101T01Z"
+    )
+    assert df['value_time'].unique().size == 3
 
-#     # Test Puerto Rico ANA
-#     df = setup_gcp.get(
-#         configuration="analysis_assim_puertorico",
-#         reference_time="20210501T00Z"
-#     )
-#     assert df['value_time'].unique().size == 3
+    # Test Hawaii Short Range
+    df = setup_gcp.get(
+        configuration="short_range_hawaii",
+        reference_time="20210101T00Z"
+    )
+    assert df['value_time'].unique().size == 60
 
-#     # Test Puerto Rico Short Range
-#     df = setup_gcp.get(
-#         configuration="short_range_puertorico",
-#         reference_time="20210501T06Z"
-#     )
-#     assert df['value_time'].unique().size == 48
+    # Test Puerto Rico ANA
+    df = setup_gcp.get(
+        configuration="analysis_assim_puertorico",
+        reference_time="20210501T00Z"
+    )
+    assert df['value_time'].unique().size == 3
 
-# @pytest.mark.slow
-# def test_get_no_da(setup_gcp):
-#     # No DA Cycles
-#     cycles = [
-#         ('analysis_assim_no_da', "20210501T06Z", 3),
-#         ('analysis_assim_extend_no_da', "20210501T16Z", 28),
-#         ('analysis_assim_hawaii_no_da', "20210501T00Z", 12),
-#         ('analysis_assim_long_no_da', "20210501T00Z", 12),
-#         ('analysis_assim_puertorico_no_da', "20210501T00Z", 3),
-#         ('medium_range_no_da', "20210501T00Z", 80),
-#         ('short_range_hawaii_no_da', "20210501T00Z", 192),
-#         ('short_range_puertorico_no_da', "20210501T06Z", 48)
-#     ]
-#     # Test
-#     for cycle, ref_tm, validate in cycles:
-#         df = setup_gcp.get(
-#             configuration=cycle,
-#             reference_time=ref_tm
-#         )
-#         assert df['value_time'].unique().size == validate
+    # Test Puerto Rico Short Range
+    df = setup_gcp.get(
+        configuration="short_range_puertorico",
+        reference_time="20210501T06Z"
+    )
+    assert df['value_time'].unique().size == 48
 
-# def test_invalid_configuration_exception(setup_gcp):
-#     # Test invalid configuration
-#     with pytest.raises(Exception):
-#         df = setup_gcp.get(
-#             configuration="medium_range",
-#             reference_time="20210101T06Z"
-#         )
+@pytest.mark.slow
+def test_get_no_da(setup_gcp):
+    # No DA Cycles
+    cycles = [
+        ('analysis_assim_no_da', "20210501T06Z", 3),
+        ('analysis_assim_extend_no_da', "20210501T16Z", 28),
+        ('analysis_assim_hawaii_no_da', "20210501T00Z", 12),
+        ('analysis_assim_long_no_da', "20210501T00Z", 12),
+        ('analysis_assim_puertorico_no_da', "20210501T00Z", 3),
+        ('medium_range_no_da', "20210501T00Z", 80),
+        ('short_range_hawaii_no_da', "20210501T00Z", 192),
+        ('short_range_puertorico_no_da', "20210501T06Z", 48)
+    ]
+    # Test
+    for cycle, ref_tm, validate in cycles:
+        df = setup_gcp.get(
+            configuration=cycle,
+            reference_time=ref_tm
+        )
+        assert df['value_time'].unique().size == validate
+
+def test_invalid_configuration_exception(setup_gcp):
+    # Test invalid configuration
+    with pytest.raises(Exception):
+        df = setup_gcp.get(
+            configuration="medium_range",
+            reference_time="20210101T06Z"
+        )

--- a/python/gcp_client/tests/test_gcp.py
+++ b/python/gcp_client/tests/test_gcp.py
@@ -101,7 +101,7 @@ def test_get_cycle(setup_gcp):
         configuration="analysis_assim",
         reference_time="20210101T01Z"
     )
-    assert df['valid_time'].unique().size == 3
+    assert df['value_time'].unique().size == 3
 
 @pytest.mark.slow
 def test_cache_disable(setup_gcp):
@@ -113,7 +113,7 @@ def test_cache_disable(setup_gcp):
         reference_time="20210101T01Z",
         cache_data=False
     )
-    assert df['valid_time'].unique().size == 3
+    assert df['value_time'].unique().size == 3
     assert not setup_gcp.cache_path.exists()
 
 @pytest.mark.slow
@@ -124,11 +124,11 @@ def test_cache_key(setup_gcp):
         reference_time="20210101T02Z",
         cache_data=True
     )
-    first = df1['valid_time'].unique().size
+    first = df1['value_time'].unique().size
 
     with pd.HDFStore(setup_gcp.cache_path) as store:
         df2 = store[f"/{setup_gcp.cache_group}/analysis_assim/DT20210101T02Z"]
-        second = df2['valid_time'].unique().size
+        second = df2['value_time'].unique().size
     assert first == second
 
 @pytest.mark.slow
@@ -138,63 +138,63 @@ def test_get(setup_gcp):
         configuration="analysis_assim",
         reference_time="20210101T01Z"
     )
-    assert df['valid_time'].unique().size == 3
+    assert df['value_time'].unique().size == 3
 
     # Test Ext. ANA
     df = setup_gcp.get(
         configuration="analysis_assim_extend",
         reference_time="20210101T16Z"
     )
-    assert df['valid_time'].unique().size == 28
+    assert df['value_time'].unique().size == 28
 
     # Test short range
     df = setup_gcp.get(
         configuration="short_range",
         reference_time="20210101T01Z"
     )
-    assert df['valid_time'].unique().size == 18
+    assert df['value_time'].unique().size == 18
 
     # Test medium range
     df = setup_gcp.get(
         configuration="medium_range_mem1",
         reference_time="20210101T06Z"
     )
-    assert df['valid_time'].unique().size == 80
+    assert df['value_time'].unique().size == 80
 
     # Test long range
     df = setup_gcp.get(
         configuration="long_range_mem1",
         reference_time="20210101T06Z"
     )
-    assert df['valid_time'].unique().size == 120
+    assert df['value_time'].unique().size == 120
 
     # Test Hawaii ANA
     df = setup_gcp.get(
         configuration="analysis_assim_hawaii",
         reference_time="20210101T01Z"
     )
-    assert df['valid_time'].unique().size == 3
+    assert df['value_time'].unique().size == 3
 
     # Test Hawaii Short Range
     df = setup_gcp.get(
         configuration="short_range_hawaii",
         reference_time="20210101T00Z"
     )
-    assert df['valid_time'].unique().size == 60
+    assert df['value_time'].unique().size == 60
 
     # Test Puerto Rico ANA
     df = setup_gcp.get(
         configuration="analysis_assim_puertorico",
         reference_time="20210501T00Z"
     )
-    assert df['valid_time'].unique().size == 3
+    assert df['value_time'].unique().size == 3
 
     # Test Puerto Rico Short Range
     df = setup_gcp.get(
         configuration="short_range_puertorico",
         reference_time="20210501T06Z"
     )
-    assert df['valid_time'].unique().size == 48
+    assert df['value_time'].unique().size == 48
 
 @pytest.mark.slow
 def test_get_no_da(setup_gcp):
@@ -215,7 +215,7 @@ def test_get_no_da(setup_gcp):
             configuration=cycle,
             reference_time=ref_tm
         )
-        assert df['valid_time'].unique().size == validate
+        assert df['value_time'].unique().size == validate
 
 def test_invalid_configuration_exception(setup_gcp):
     # Test invalid configuration

--- a/python/gcp_client/tests/test_gcp.py
+++ b/python/gcp_client/tests/test_gcp.py
@@ -25,202 +25,204 @@ def test_crosswalk(setup_gcp):
     with pytest.raises(Exception):
         setup_gcp.crosswalk = pd.DataFrame()
 
-def test_cache_path(setup_gcp):
-    assert str(setup_gcp.cache_path) == 'gcp_client.h5'
+    assert setup_gcp.crosswalk.loc[6186112, "usgs_site_code"] == "01360640"
 
-    setup_gcp.cache_path = 'custom_cache.h5'
-    assert str(setup_gcp.cache_path) == 'custom_cache.h5'
+# def test_cache_path(setup_gcp):
+#     assert str(setup_gcp.cache_path) == 'gcp_client.h5'
 
-def test_cache_group(setup_gcp):
-    assert str(setup_gcp.cache_group) == 'gcp_client'
+#     setup_gcp.cache_path = 'custom_cache.h5'
+#     assert str(setup_gcp.cache_path) == 'custom_cache.h5'
 
-    setup_gcp.cache_group = 'simulations'
-    assert str(setup_gcp.cache_group) == 'simulations'
+# def test_cache_group(setup_gcp):
+#     assert str(setup_gcp.cache_group) == 'gcp_client'
 
-@pytest.mark.slow
-def test_list_blobs(setup_gcp):
-    blob_list = setup_gcp.list_blobs(
-        configuration="short_range",
-        reference_time="20210101T01Z"
-    )
+#     setup_gcp.cache_group = 'simulations'
+#     assert str(setup_gcp.cache_group) == 'simulations'
 
-    assert len(blob_list) == 18
+# @pytest.mark.slow
+# def test_list_blobs(setup_gcp):
+#     blob_list = setup_gcp.list_blobs(
+#         configuration="short_range",
+#         reference_time="20210101T01Z"
+#     )
 
-@pytest.mark.slow
-def test_get_blob(setup_gcp):
-    blob_name = "nwm.20210101/short_range/nwm.t01z.short_range.channel_rt.f001.conus.nc"
-    blob_data = setup_gcp.get_blob(blob_name)
-    assert type(blob_data) == bytes
+#     assert len(blob_list) == 18
 
-@pytest.mark.slow
-def test_get_Dataset(setup_gcp):
-    blob_name = "nwm.20210101/short_range/nwm.t01z.short_range.channel_rt.f001.conus.nc"
+# @pytest.mark.slow
+# def test_get_blob(setup_gcp):
+#     blob_name = "nwm.20210101/short_range/nwm.t01z.short_range.channel_rt.f001.conus.nc"
+#     blob_data = setup_gcp.get_blob(blob_name)
+#     assert type(blob_data) == bytes
+
+# @pytest.mark.slow
+# def test_get_Dataset(setup_gcp):
+#     blob_name = "nwm.20210101/short_range/nwm.t01z.short_range.channel_rt.f001.conus.nc"
     
-    # Test default filter
-    ds = setup_gcp.get_Dataset(blob_name)
-    assert ds.feature_id.size > 4000
-    assert ds.feature_id.size < 8000
+#     # Test default filter
+#     ds = setup_gcp.get_Dataset(blob_name)
+#     assert ds.feature_id.size > 4000
+#     assert ds.feature_id.size < 8000
 
-    # Test filter with list
-    ds = setup_gcp.get_Dataset(blob_name, 
-        feature_id_filter=[101, 179])
-    assert ds.feature_id.size == 2
+#     # Test filter with list
+#     ds = setup_gcp.get_Dataset(blob_name, 
+#         feature_id_filter=[101, 179])
+#     assert ds.feature_id.size == 2
 
-    # Test filter with numpy.array
-    ds = setup_gcp.get_Dataset(blob_name, 
-        feature_id_filter=np.asarray([101, 179]))
-    assert ds.feature_id.size == 2
+#     # Test filter with numpy.array
+#     ds = setup_gcp.get_Dataset(blob_name, 
+#         feature_id_filter=np.asarray([101, 179]))
+#     assert ds.feature_id.size == 2
 
-    # Test filter with pandas.Series
-    features = pd.Series(data=[101, 179])
-    ds = setup_gcp.get_Dataset(blob_name, 
-        feature_id_filter=features)
-    assert ds.feature_id.size == 2
+#     # Test filter with pandas.Series
+#     features = pd.Series(data=[101, 179])
+#     ds = setup_gcp.get_Dataset(blob_name, 
+#         feature_id_filter=features)
+#     assert ds.feature_id.size == 2
 
-    # Test no filter
-    ds = setup_gcp.get_Dataset(blob_name, 
-        feature_id_filter=False)
-    assert ds.feature_id.size > 8000
+#     # Test no filter
+#     ds = setup_gcp.get_Dataset(blob_name, 
+#         feature_id_filter=False)
+#     assert ds.feature_id.size > 8000
 
-@pytest.mark.slow
-def test_get_DataFrame(setup_gcp):
-    blob_name = "nwm.20210101/short_range/nwm.t01z.short_range.channel_rt.f001.conus.nc"
+# @pytest.mark.slow
+# def test_get_DataFrame(setup_gcp):
+#     blob_name = "nwm.20210101/short_range/nwm.t01z.short_range.channel_rt.f001.conus.nc"
     
-    # Test default
-    df = setup_gcp.get_DataFrame(blob_name)
-    assert len(df.columns) == 4
+#     # Test default
+#     df = setup_gcp.get_DataFrame(blob_name)
+#     assert len(df.columns) == 4
 
-    # Test all variables
-    df = setup_gcp.get_DataFrame(blob_name, streamflow_only=False)
-    assert len(df.columns) > 4
+#     # Test all variables
+#     df = setup_gcp.get_DataFrame(blob_name, streamflow_only=False)
+#     assert len(df.columns) > 4
 
-@pytest.mark.slow
-def test_get_cycle(setup_gcp):
-    # Test ANA
-    df = setup_gcp.get_cycle(
-        configuration="analysis_assim",
-        reference_time="20210101T01Z"
-    )
-    assert df['value_time'].unique().size == 3
+# @pytest.mark.slow
+# def test_get_cycle(setup_gcp):
+#     # Test ANA
+#     df = setup_gcp.get_cycle(
+#         configuration="analysis_assim",
+#         reference_time="20210101T01Z"
+#     )
+#     assert df['value_time'].unique().size == 3
 
-@pytest.mark.slow
-def test_cache_disable(setup_gcp):
-    setup_gcp.cache_path = 'disabled_cache.h5'
+# @pytest.mark.slow
+# def test_cache_disable(setup_gcp):
+#     setup_gcp.cache_path = 'disabled_cache.h5'
 
-    # Test ANA
-    df = setup_gcp.get(
-        configuration="analysis_assim",
-        reference_time="20210101T01Z",
-        cache_data=False
-    )
-    assert df['value_time'].unique().size == 3
-    assert not setup_gcp.cache_path.exists()
+#     # Test ANA
+#     df = setup_gcp.get(
+#         configuration="analysis_assim",
+#         reference_time="20210101T01Z",
+#         cache_data=False
+#     )
+#     assert df['value_time'].unique().size == 3
+#     assert not setup_gcp.cache_path.exists()
 
-@pytest.mark.slow
-def test_cache_key(setup_gcp):
-    # Test ANA
-    df1 = setup_gcp.get(
-        configuration="analysis_assim",
-        reference_time="20210101T02Z",
-        cache_data=True
-    )
-    first = df1['value_time'].unique().size
+# @pytest.mark.slow
+# def test_cache_key(setup_gcp):
+#     # Test ANA
+#     df1 = setup_gcp.get(
+#         configuration="analysis_assim",
+#         reference_time="20210101T02Z",
+#         cache_data=True
+#     )
+#     first = df1['value_time'].unique().size
 
-    with pd.HDFStore(setup_gcp.cache_path) as store:
-        df2 = store[f"/{setup_gcp.cache_group}/analysis_assim/DT20210101T02Z"]
-        second = df2['value_time'].unique().size
-    assert first == second
+#     with pd.HDFStore(setup_gcp.cache_path) as store:
+#         df2 = store[f"/{setup_gcp.cache_group}/analysis_assim/DT20210101T02Z"]
+#         second = df2['value_time'].unique().size
+#     assert first == second
 
-@pytest.mark.slow
-def test_get(setup_gcp):
-    # Test ANA
-    df = setup_gcp.get(
-        configuration="analysis_assim",
-        reference_time="20210101T01Z"
-    )
-    assert df['value_time'].unique().size == 3
+# @pytest.mark.slow
+# def test_get(setup_gcp):
+#     # Test ANA
+#     df = setup_gcp.get(
+#         configuration="analysis_assim",
+#         reference_time="20210101T01Z"
+#     )
+#     assert df['value_time'].unique().size == 3
 
-    # Test Ext. ANA
-    df = setup_gcp.get(
-        configuration="analysis_assim_extend",
-        reference_time="20210101T16Z"
-    )
-    assert df['value_time'].unique().size == 28
+#     # Test Ext. ANA
+#     df = setup_gcp.get(
+#         configuration="analysis_assim_extend",
+#         reference_time="20210101T16Z"
+#     )
+#     assert df['value_time'].unique().size == 28
 
-    # Test short range
-    df = setup_gcp.get(
-        configuration="short_range",
-        reference_time="20210101T01Z"
-    )
-    assert df['value_time'].unique().size == 18
+#     # Test short range
+#     df = setup_gcp.get(
+#         configuration="short_range",
+#         reference_time="20210101T01Z"
+#     )
+#     assert df['value_time'].unique().size == 18
 
-    # Test medium range
-    df = setup_gcp.get(
-        configuration="medium_range_mem1",
-        reference_time="20210101T06Z"
-    )
-    assert df['value_time'].unique().size == 80
+#     # Test medium range
+#     df = setup_gcp.get(
+#         configuration="medium_range_mem1",
+#         reference_time="20210101T06Z"
+#     )
+#     assert df['value_time'].unique().size == 80
 
-    # Test long range
-    df = setup_gcp.get(
-        configuration="long_range_mem1",
-        reference_time="20210101T06Z"
-    )
-    assert df['value_time'].unique().size == 120
+#     # Test long range
+#     df = setup_gcp.get(
+#         configuration="long_range_mem1",
+#         reference_time="20210101T06Z"
+#     )
+#     assert df['value_time'].unique().size == 120
 
-    # Test Hawaii ANA
-    df = setup_gcp.get(
-        configuration="analysis_assim_hawaii",
-        reference_time="20210101T01Z"
-    )
-    assert df['value_time'].unique().size == 3
+#     # Test Hawaii ANA
+#     df = setup_gcp.get(
+#         configuration="analysis_assim_hawaii",
+#         reference_time="20210101T01Z"
+#     )
+#     assert df['value_time'].unique().size == 3
 
-    # Test Hawaii Short Range
-    df = setup_gcp.get(
-        configuration="short_range_hawaii",
-        reference_time="20210101T00Z"
-    )
-    assert df['value_time'].unique().size == 60
+#     # Test Hawaii Short Range
+#     df = setup_gcp.get(
+#         configuration="short_range_hawaii",
+#         reference_time="20210101T00Z"
+#     )
+#     assert df['value_time'].unique().size == 60
 
-    # Test Puerto Rico ANA
-    df = setup_gcp.get(
-        configuration="analysis_assim_puertorico",
-        reference_time="20210501T00Z"
-    )
-    assert df['value_time'].unique().size == 3
+#     # Test Puerto Rico ANA
+#     df = setup_gcp.get(
+#         configuration="analysis_assim_puertorico",
+#         reference_time="20210501T00Z"
+#     )
+#     assert df['value_time'].unique().size == 3
 
-    # Test Puerto Rico Short Range
-    df = setup_gcp.get(
-        configuration="short_range_puertorico",
-        reference_time="20210501T06Z"
-    )
-    assert df['value_time'].unique().size == 48
+#     # Test Puerto Rico Short Range
+#     df = setup_gcp.get(
+#         configuration="short_range_puertorico",
+#         reference_time="20210501T06Z"
+#     )
+#     assert df['value_time'].unique().size == 48
 
-@pytest.mark.slow
-def test_get_no_da(setup_gcp):
-    # No DA Cycles
-    cycles = [
-        ('analysis_assim_no_da', "20210501T06Z", 3),
-        ('analysis_assim_extend_no_da', "20210501T16Z", 28),
-        ('analysis_assim_hawaii_no_da', "20210501T00Z", 12),
-        ('analysis_assim_long_no_da', "20210501T00Z", 12),
-        ('analysis_assim_puertorico_no_da', "20210501T00Z", 3),
-        ('medium_range_no_da', "20210501T00Z", 80),
-        ('short_range_hawaii_no_da', "20210501T00Z", 192),
-        ('short_range_puertorico_no_da', "20210501T06Z", 48)
-    ]
-    # Test
-    for cycle, ref_tm, validate in cycles:
-        df = setup_gcp.get(
-            configuration=cycle,
-            reference_time=ref_tm
-        )
-        assert df['value_time'].unique().size == validate
+# @pytest.mark.slow
+# def test_get_no_da(setup_gcp):
+#     # No DA Cycles
+#     cycles = [
+#         ('analysis_assim_no_da', "20210501T06Z", 3),
+#         ('analysis_assim_extend_no_da', "20210501T16Z", 28),
+#         ('analysis_assim_hawaii_no_da', "20210501T00Z", 12),
+#         ('analysis_assim_long_no_da', "20210501T00Z", 12),
+#         ('analysis_assim_puertorico_no_da', "20210501T00Z", 3),
+#         ('medium_range_no_da', "20210501T00Z", 80),
+#         ('short_range_hawaii_no_da', "20210501T00Z", 192),
+#         ('short_range_puertorico_no_da', "20210501T06Z", 48)
+#     ]
+#     # Test
+#     for cycle, ref_tm, validate in cycles:
+#         df = setup_gcp.get(
+#             configuration=cycle,
+#             reference_time=ref_tm
+#         )
+#         assert df['value_time'].unique().size == validate
 
-def test_invalid_configuration_exception(setup_gcp):
-    # Test invalid configuration
-    with pytest.raises(Exception):
-        df = setup_gcp.get(
-            configuration="medium_range",
-            reference_time="20210101T06Z"
-        )
+# def test_invalid_configuration_exception(setup_gcp):
+#     # Test invalid configuration
+#     with pytest.raises(Exception):
+#         df = setup_gcp.get(
+#             configuration="medium_range",
+#             reference_time="20210101T06Z"
+#         )


### PR DESCRIPTION
This alters the behavior of `gcp_client` tool to return `nwm_feature_id` as `int` instead of string categories. This will simplify the interface and address a bug associated with trying to map crosswalk data across category types. Note: Keeping feature IDs as integers was originally suggested by @aaraney 

## Additions

- Additional tests do limited (single site) validation of crosswalk application.

## Removals

- any conversion of `nwm_feature_id` to str and/or category

## Changes

- `nwm_feature_id` are now always integers

## Testing

1. Test that feature id 6186112 is associated with usgs_site_code "01360640"


## Notes

- No more reviewers :(

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
