### PR TITLE
events: Default to decaying adjustment factor

### DIFF
--- a/python/events/hydrotools/events/event_detection/decomposition.py
+++ b/python/events/hydrotools/events/event_detection/decomposition.py
@@ -110,7 +110,7 @@ def detrend_streamflow(
 
     # Smooth series
     smooth = series.ewm(halflife=halflife, times=series.index, 
-        adjust=False).mean()
+        adjust=True).mean()
     
     # Estimate a trend using a rolling minimum
     trend = rolling_minimum(smooth, window)

--- a/python/events/setup.py
+++ b/python/events/setup.py
@@ -14,7 +14,7 @@ SUBPACKAGE_NAME = "events"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "1.0.2"
+VERSION = "1.1.2"
 
 # Package author information
 AUTHOR = "Jason Regina"


### PR DESCRIPTION
Recent versions of pandas no longer allow the combination of a halflife with the recursive version of the EWMA. This changes the default to use a decaying adjustment factor.

## Additions

- None

## Removals

- None

## Changes

- Use decaying adjustment factor.

## Testing

1. Passes tests.


## Notes

- Slight change to EWMA algorithm.

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
