### PR TITLE
GCP Client: Switch from mp to futures

### DIFF
--- a/python/gcp_client/setup.py
+++ b/python/gcp_client/setup.py
@@ -14,7 +14,7 @@ SUBPACKAGE_NAME = "gcp_client"
 SUBPACKAGE_SLUG = f"{NAMESPACE_PACKAGE_NAME}.{SUBPACKAGE_NAME}"
 
 # Subpackage version
-VERSION = "4.0.0"
+VERSION = "4.1.0"
 
 # Package author information
 AUTHOR = "Jason Regina"


### PR DESCRIPTION
Switch from using `multiprocessing.Pool` to `concurrent.futures.ProcessPoolExecutor`. This is partially a future-proof update to use the available generic interface for concurrency and offers a potential speed-up through the use of chunking.

## Additions

- None

## Removals

- None

## Changes

- Switched from using `Pool` to `ProcessPoolExecutor`

## Testing

1. Passed all existing tests.


## Notes

- Closes #101 

## Todos

- None

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
