### PR TITLE
Warn for Null values in series when calling event detection

### DIFF
--- a/python/events/setup.cfg
+++ b/python/events/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = hydrotools.events
-version = 1.1.4
+version = 1.1.5
 author = Jason A. Regina
 author_email = jason.regina@noaa.gov
 description = Various methods to support event-based evaluations.

--- a/python/events/src/hydrotools/events/event_detection/decomposition.py
+++ b/python/events/src/hydrotools/events/event_detection/decomposition.py
@@ -24,6 +24,7 @@ import numpy as np
 import pandas as pd
 from typing import Union
 import datetime
+import warnings
 
 def rolling_minimum(
     series: pd.Series,
@@ -107,6 +108,10 @@ def detrend_streamflow(
 
     if series.index.has_duplicates:
         raise Exception("series index has duplicate timestamps")
+
+    # Check values
+    if series.isnull().any():
+        warnings.warn("Series contains null values.", UserWarning)
 
     # Smooth series
     smooth = series.ewm(halflife=halflife, times=series.index, 

--- a/python/events/tests/test_decomposition.py
+++ b/python/events/tests/test_decomposition.py
@@ -141,3 +141,18 @@ def test_bad_time_series_idx():
     )
     with pytest.raises(Exception):
         events = ev.list_events(series, '6H', '7D')
+
+def test_null_warning():
+    series = pd.Series(
+        data=[1.0, 1.0, np.nan, 1.0, 1.0],
+        index=[
+            pd.to_datetime('2018-01-01 01:00'),
+            pd.to_datetime('2018-01-01 02:00'),
+            pd.to_datetime('2018-01-01 03:00'),
+            pd.to_datetime('2018-01-01 04:00'),
+            pd.to_datetime('2018-01-01 05:00')
+        ],
+        name='streamflow'
+    )
+    with pytest.warns(UserWarning):
+        events = ev.list_events(series, '6H', '7D')


### PR DESCRIPTION
Warn the user if event detection is called on a series with null values. Closes #51 

## Additions

- UserWarning when calling detrend_series that contains null values

## Removals

- None

## Changes

- None

## Testing

1. Warning is tested.


## Notes

- Docs/README still recommends to fill null values.

## Todos

- None

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
