### PR TITLE
Update package level installation makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,20 @@ SUBPACKAGES_WITHOUT_EXTRA_REQUIRE = $(shell echo $(SUBPACKAGES) | sed 's|\[[^][]
 # relative path to subpackages (e.g. ./python/nwis_client)
 SUBPACKAGES_PATHS := $(addprefix $(NAMESPACE_DIR), $(SUBPACKAGES))
 
-.PHONY: all-tests tests install clean
+.PHONY: help all-tests tests install uninstall develop clean
+
+help:
+	    @echo "HydroTools makefile commands:"
+	    @echo "  install : install all subpackages from local source code"
+	    @echo "  develop : install all subpackages in editable mode (pip -e) from local source code"
+	    @echo "  tests : run unit tests. exclude tests marked as slow"
+	    @echo "  all-tests : run all unit tests"
+	    @echo "  uninstall : uninstall all subpackages"
+	    @echo "  clean : delete python virtual environment"
+		@echo
+		@echo "  this utility requires sed"
+
+.DEFAULT_GOAL := help
 
 tests: install
 	$(PYTHON) -m pytest -s -m "not slow"

--- a/Makefile
+++ b/Makefile
@@ -20,12 +20,7 @@ all-tests: install
 	$(PYTHON) -m pytest -s
 
 install: $(PYENV)/bin/activate
-	$(PYTHON) -m pip install --use-feature=in-tree-build ./python/_restclient[develop]
-	$(PYTHON) -m pip install --use-feature=in-tree-build ./python/nwis_client[develop]
-	$(PYTHON) -m pip install --use-feature=in-tree-build ./python/caches[develop]
-	$(PYTHON) -m pip install --use-feature=in-tree-build ./python/nwm_client[gcp,develop]
-	$(PYTHON) -m pip install --use-feature=in-tree-build ./python/events[develop]
-	$(PYTHON) -m pip install --use-feature=in-tree-build ./python/metrics[develop]
+	$(PYTHON) -m pip install --use-feature=in-tree-build $(SUBPACKAGES_PATHS)
 
 $(PYENV)/bin/activate:
 	test -d $(PYENV) || python3 -m venv $(PYENV)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,15 @@
 PYENV=env
 PYTHON=$(PYENV)/bin/python3
+NAMESPACE_DIR := ./python/
+
+PACKAGE := hydrotools
+SUBPACKAGES := _restclient[develop] nwis_client[develop] caches[develop] nwm_client[gcp,develop] events[develop] metrics[develop]
+
+# discard `extras_require` qualifies from subpackage names (e.g. [develop])
+SUBPACKAGES_WITHOUT_EXTRA_REQUIRE = $(shell echo $(SUBPACKAGES) | sed 's|\[[^][]*\]||g')
+
+# relative path to subpackages (e.g. ./python/nwis_client)
+SUBPACKAGES_PATHS := $(addprefix $(NAMESPACE_DIR), $(SUBPACKAGES))
 
 .PHONY: all-tests tests install clean
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,12 @@ all-tests: install
 install: $(PYENV)/bin/activate
 	$(PYTHON) -m pip install --use-feature=in-tree-build $(SUBPACKAGES_PATHS)
 
+uninstall: $(PYENV)/bin/activate
+	$(PYTHON) -m pip uninstall -y $(addprefix $(PACKAGE)., $(SUBPACKAGES_WITHOUT_EXTRA_REQUIRE))
+
+develop: $(PYENV)/bin/activate
+	$(PYTHON) -m pip install --editable --use-feature=in-tree-build $(SUBPACKAGES_PATHS)
+
 $(PYENV)/bin/activate:
 	test -d $(PYENV) || python3 -m venv $(PYENV)
 	$(PYTHON) -m pip install -U pip wheel setuptools build pytest


### PR DESCRIPTION
Cleanup and add a small amount of functionality to package level makefile. Add new `develop` and `uninstall` rules for installing all packages in editable (`pip install -e`) mode and uninstalling all subpackages from the virtual environment respectfully.  A help page to display available rules and a brief description is also added.

help page:
```shell
HydroTools makefile commands:
  install : install all subpackages from local source code
  develop : install all subpackages in editable mode (pip -e) from local source code
  tests : run unit tests. exclude tests marked as slow
  all-tests : run all unit tests
  uninstall : uninstall all subpackages
  clean : delete python virtual environment

  this utility requires sed
```

## Additions

- `help` rule (default rule). displays available rules and a brief description
- `develop` rule. Installs all subpackages using `pip install --editable`
- `uninstall` rule. Uninstalls all subpackages from the virtual environment

## Removals

-

## Changes

-

## Testing

1.


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
