### PR TITLE
Add setup.py back to subpackages

### DIFF
--- a/python/_restclient/setup.py
+++ b/python/_restclient/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+# required to install package in editable mode `pip install -e`
+setup()

--- a/python/caches/setup.py
+++ b/python/caches/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+# required to install package in editable mode `pip install -e`
+setup()

--- a/python/events/setup.py
+++ b/python/events/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+# required to install package in editable mode `pip install -e`
+setup()

--- a/python/gcp_client/setup.py
+++ b/python/gcp_client/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+# required to install package in editable mode `pip install -e`
+setup()

--- a/python/metrics/setup.py
+++ b/python/metrics/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+# required to install package in editable mode `pip install -e`
+setup()

--- a/python/nwis_client/setup.py
+++ b/python/nwis_client/setup.py
@@ -1,0 +1,4 @@
+from setuptools import setup
+
+# required to install package in editable mode `pip install -e`
+setup()


### PR DESCRIPTION
`setup.py` with a void call to `setuptools.setup()` is required to install packages in editable mode.

Related to #128.

## Additions

-

## Removals

-

## Changes

- Add `setup.py` back to subpackages to enable installing in editable mode.

## Testing

1.


## Notes

-

## Todos

-

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
