### PR TITLE
fix nwis_client bug causing KeyError when station does not return data -- Updated

### DIFF
--- a/python/nwis_client/setup.cfg
+++ b/python/nwis_client/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = hydrotools.nwis_client
-version = 3.0.4
+version = 3.0.5
 author = Austin Raney
 author_email = aaraney@protonmail.com
 description = A convenient interface to the USGS NWIS Instantaneous Values (IV) REST Service API.

--- a/python/nwis_client/src/hydrotools/nwis_client/iv.py
+++ b/python/nwis_client/src/hydrotools/nwis_client/iv.py
@@ -249,6 +249,12 @@ class IVDataService:
 
         list_of_frames = list(map(list_to_df_helper, raw_data))
 
+        # Empty list. No data was returned in the request
+        if not list_of_frames:
+            warning_message = "No data was returned by the request."
+            warnings.warn(warning_message)
+            return _create_empty_canonical_df()
+
         # Concatenate list in single pd.DataFrame
         dfs = pd.concat(list_of_frames, ignore_index=True)
 

--- a/python/nwis_client/src/hydrotools/nwis_client/iv.py
+++ b/python/nwis_client/src/hydrotools/nwis_client/iv.py
@@ -249,12 +249,6 @@ class IVDataService:
 
         list_of_frames = list(map(list_to_df_helper, raw_data))
 
-        # Empty list. No data was returned in the request
-        if not list_of_frames:
-            warning_message = "No data was returned by the request."
-            warnings.warn(warning_message)
-            return pd.DataFrame(None)
-
         # Concatenate list in single pd.DataFrame
         dfs = pd.concat(list_of_frames, ignore_index=True)
 

--- a/python/nwis_client/src/hydrotools/nwis_client/iv.py
+++ b/python/nwis_client/src/hydrotools/nwis_client/iv.py
@@ -252,6 +252,10 @@ class IVDataService:
         # Concatenate list in single pd.DataFrame
         dfs = pd.concat(list_of_frames, ignore_index=True)
 
+        # skip data processing steps if no data was retrieved and return empty canonical df
+        if dfs.empty:
+            return _create_empty_canonical_df()
+
         # Convert values to numbers
         dfs.loc[:, "value"] = pd.to_numeric(dfs["value"], downcast="float")
 

--- a/python/nwis_client/src/hydrotools/nwis_client/iv.py
+++ b/python/nwis_client/src/hydrotools/nwis_client/iv.py
@@ -809,3 +809,17 @@ def _bbox_split(values: Union[str, list, tuple, pd.Series, np.ndarray]) -> List[
     value_groups = np.array_split(values, n_groups)
 
     return list(map(lambda i: ",".join(i), value_groups))
+
+
+def _create_empty_canonical_df() -> pd.DataFrame:
+    """Returns an empty hydrotools canonical dataframe with correct field datatypes."""
+    cols = {
+        "value_time": pd.Series(dtype="datetime64[ns]"),
+        "variable_name": pd.Series(dtype="category"),
+        "usgs_site_code": pd.Series(dtype="category"),
+        "measurement_unit": pd.Series(dtype="category"),
+        "value": pd.Series(dtype="float32"),
+        "qualifiers": pd.Series(dtype="category"),
+        "series": pd.Series(dtype="category"),
+    }
+    return pd.DataFrame(cols, index=[])

--- a/python/nwis_client/src/hydrotools/nwis_client/iv.py
+++ b/python/nwis_client/src/hydrotools/nwis_client/iv.py
@@ -256,7 +256,9 @@ class IVDataService:
         # Empty list. No data was returned in the request
         if not list_of_frames:
             empty_df_warning_helper()
-            return _create_empty_canonical_df()
+            empty_df = _create_empty_canonical_df()
+            empty_df = empty_df.rename(columns={"value_time": self.value_time_label})
+            return empty_df
 
         # Concatenate list in single pd.DataFrame
         dfs = pd.concat(list_of_frames, ignore_index=True)
@@ -264,7 +266,9 @@ class IVDataService:
         # skip data processing steps if no data was retrieved and return empty canonical df
         if dfs.empty:
             empty_df_warning_helper()
-            return _create_empty_canonical_df()
+            empty_df = _create_empty_canonical_df()
+            empty_df = empty_df.rename(columns={"value_time": self.value_time_label})
+            return empty_df
 
         # Convert values to numbers
         dfs.loc[:, "value"] = pd.to_numeric(dfs["value"], downcast="float")

--- a/python/nwis_client/src/hydrotools/nwis_client/iv.py
+++ b/python/nwis_client/src/hydrotools/nwis_client/iv.py
@@ -247,12 +247,15 @@ class IVDataService:
 
             return df
 
+        def empty_df_warning_helper():
+            warning_message = "No data was returned by the request."
+            warnings.warn(warning_message)
+
         list_of_frames = list(map(list_to_df_helper, raw_data))
 
         # Empty list. No data was returned in the request
         if not list_of_frames:
-            warning_message = "No data was returned by the request."
-            warnings.warn(warning_message)
+            empty_df_warning_helper()
             return _create_empty_canonical_df()
 
         # Concatenate list in single pd.DataFrame
@@ -260,6 +263,7 @@ class IVDataService:
 
         # skip data processing steps if no data was retrieved and return empty canonical df
         if dfs.empty:
+            empty_df_warning_helper()
             return _create_empty_canonical_df()
 
         # Convert values to numbers

--- a/python/nwis_client/tests/test_nwis.py
+++ b/python/nwis_client/tests/test_nwis.py
@@ -425,14 +425,14 @@ def test_splitting_bbox(test, validation):
     assert v == validation
 
 
-def test_get_returns_empty_canonical_dataframe(setup_iv, monkeypatch):
+def test_get_returns_empty_canonical_dataframe(setup_iv_value_time, monkeypatch):
     """Verify that `get` can returns an empty canonical dataframe."""
 
     def get_raw_mock(*args, **kwargs):
         return [{"values": []}]
 
     monkeypatch.setattr(iv.IVDataService, "get_raw", get_raw_mock)
-    df = setup_iv.get(
+    df = setup_iv_value_time.get(
         sites=["01189000"], startDt="2015-12-01T00:00", endDt="2015-12-31T23:45"
     )
     canonical_df = iv._create_empty_canonical_df()

--- a/python/nwis_client/tests/test_nwis.py
+++ b/python/nwis_client/tests/test_nwis.py
@@ -423,3 +423,17 @@ SPLITTING_BBOX_PARAMS = (
 def test_splitting_bbox(test, validation):
     v = iv._bbox_split(test)
     assert v == validation
+
+
+def test_get_returns_empty_canonical_dataframe(setup_iv, monkeypatch):
+    """Verify that `get` can returns an empty canonical dataframe."""
+
+    def get_raw_mock(*args, **kwargs):
+        return [{"values": []}]
+
+    monkeypatch.setattr(iv.IVDataService, "get_raw", get_raw_mock)
+    df = setup_iv.get(
+        sites=["01189000"], startDt="2015-12-01T00:00", endDt="2015-12-31T23:45"
+    )
+    canonical_df = iv._create_empty_canonical_df()
+    assert df.equals(canonical_df)


### PR DESCRIPTION
See #133 for the bug report. This PR resolves #133. Now, when a station does not have data, `nwis_client` returns a canonical dataframe with the correct data types to the user. Additionally, the user is warned that the request did not return data. 

fixes #133

Addenda: Updates empty dataframe method to return a non-canonical dataframe if specified by the user. Necessary for #117 


## Additions

- canonical dataframe helper "private" method. This may be helpful for writing tests in the future/ asserting that dataframes comply with the standard. (see `_create_empty_canonical_df`)

## Removals

-

## Changes

- `nwis_client.get` returns a canonical dataframe with the correct data types in cases when no data is retrieved from nwis.

## Testing

1. `test_get_returns_empty_canonical_dataframe` added. Uses mock to verify a canonical dataframe is returned.


## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
