### PR TITLE
nwis_client now requires _restclient >= 3.0.4 

### DIFF
--- a/python/nwis_client/setup.cfg
+++ b/python/nwis_client/setup.cfg
@@ -32,7 +32,7 @@ package_dir =
 install_requires =
     pandas
     numpy
-    hydrotools._restclient>=3.0.2
+    hydrotools._restclient>=3.0.4
     aiohttp
 python_requires = >=3.7
 include_package_data = True


### PR DESCRIPTION
`nwis_client` now requires `_restclient` >= 3.0.4. 
solves #100

## Additions

-

## Removals

-

## Changes

- `nwis_client` now requires `_restclient` >= 3.0.4. 

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
