### PR TITLE
Resolve Nwm client IndexError: invalid index to scalar variable. (#180)

### DIFF
--- a/python/nwm_client/setup.cfg
+++ b/python/nwm_client/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     numpy>=1.20.0
     pandas
     xarray
-    h5netcdf
+    h5netcdf<=0.13.0
     hydrotools.caches>=0.1.2
     beautifulsoup4
     requests

--- a/python/nwm_client/setup.cfg
+++ b/python/nwm_client/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     numpy>=1.20.0
     pandas
     xarray
-    h5netcdf<=0.13.0
+    h5netcdf>=0.14.0
     hydrotools.caches>=0.1.2
     beautifulsoup4
     requests

--- a/python/nwm_client/src/hydrotools/nwm_client/_version.py
+++ b/python/nwm_client/src/hydrotools/nwm_client/_version.py
@@ -1,1 +1,1 @@
-__version__ = "5.0.1"
+__version__ = "5.0.1.post1"

--- a/python/nwm_client/src/hydrotools/nwm_client/_version.py
+++ b/python/nwm_client/src/hydrotools/nwm_client/_version.py
@@ -1,1 +1,1 @@
-__version__ = "5.0.1.post1"
+__version__ = "5.0.2"

--- a/python/nwm_client/src/hydrotools/nwm_client/gcp.py
+++ b/python/nwm_client/src/hydrotools/nwm_client/gcp.py
@@ -271,7 +271,7 @@ class NWMDataService:
             df = ds[['reference_time', 'time', 'streamflow']].to_dataframe().reset_index()
             
             # Extract scale factor
-            scale_factor = ds['streamflow'].scale_factor[0]
+            scale_factor = ds['streamflow'].scale_factor
             
             # Scale data
             df.loc[:, 'streamflow'] = df['streamflow'].mul(scale_factor)


### PR DESCRIPTION
See #180 for bug report. This PR lays the groundwork for two new releases of the `hydrotools.nwm_client`. The first release, `5.0.1-post1`, pins `h5netcdf<=0.13.0`. This was done to support users who would like to use the software but are dependent on a `h5netcdf<=0.13.0`. The second release is `5.0.2`, this pins `h5netcdf>=0.14.0`. `5.0.2` also includes a patch that fixes the `IndexError` propagating from `h5netcdf==0.14.0`.

fixes #180.

## Guidance

- if your application requires `h5netcdf<=0.13.0`, use `hydrotools.nwm_client==5.0.1-post1`
- otherwise, use `hydrotools.nwm_client>=5.0.2`

## Changes

- Resolves `IndexError: invalid index to scalar variable.` present in `hydrotools.nwm_client<=5.0.1`


## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
