### PR TITLE
Make map conversions more efficient.

### DIFF
--- a/python/metrics/src/hydrotools/metrics/metrics.py
+++ b/python/metrics/src/hydrotools/metrics/metrics.py
@@ -259,7 +259,7 @@ def convert_mapping_values(
     """
     # Build object of same type of mapping
     d = type(mapping)()
-    d.update(zip(mapping.keys(), map(converter, mapping.values())))
+    d.update(zip(mapping.keys(), np.fromiter(mapping.values(), dtype=converter)))
     return d
 
 

--- a/python/metrics/src/hydrotools/metrics/metrics.py
+++ b/python/metrics/src/hydrotools/metrics/metrics.py
@@ -236,7 +236,7 @@ def compute_contingency_table(
         })
 
 def convert_mapping_values(
-    mapping: Mapping[str, npt.DTypeLike],
+    mapping: MutableMapping[str, npt.DTypeLike],
     converter: np.dtype = np.float64
     ) -> MutableMapping:
     """Convert mapping values to a consistent type. Primarily used to validate 
@@ -257,13 +257,11 @@ def convert_mapping_values(
         New mapping with converted values.
         
     """
-    # Populate new dictionary with converted values
-    d = {}
-    for key, value in dict(mapping).items():
-        d[key] = converter(value)
+    # Build object of same type of mapping
+    d = type(mapping)()
+    d.update(zip(d.keys(), map(converter, d.values())))
+    return d
 
-    # Return new mapping with same type as original
-    return type(mapping)(d)
 
 def probability_of_detection(
     contingency_table: Union[dict, pd.DataFrame, pd.Series],

--- a/python/metrics/src/hydrotools/metrics/metrics.py
+++ b/python/metrics/src/hydrotools/metrics/metrics.py
@@ -259,7 +259,7 @@ def convert_mapping_values(
     """
     # Build object of same type of mapping
     d = type(mapping)()
-    d.update(zip(d.keys(), map(converter, d.values())))
+    d.update(zip(mapping.keys(), map(converter, mapping.values())))
     return d
 
 


### PR DESCRIPTION
## Changes
* Make `convert_mapping_values` work more efficiently (for a dict of length 1000, runtime drops from 471us to 294us on my machine)

## Notes
Since the numpy dtypes are C functions, pushing the loop into C (by using map) will be far more efficient.

There was a type mismatch between the type of mapping and the return of the function. Updated the type of mapping to be MutableMapping.

