### PR TITLE
Add pytest-aiohttp development  dep to svi_client

### DIFF
--- a/python/svi_client/setup.cfg
+++ b/python/svi_client/setup.cfg
@@ -47,3 +47,4 @@ where = src
 [options.extras_require]
 develop =
     pytest
+    pytest-aiohttp

--- a/python/svi_client/tests/test_integration.py
+++ b/python/svi_client/tests/test_integration.py
@@ -63,7 +63,7 @@ GEOGRAPHIC_SCALES = ("county", "census_tract")
 @pytest.mark.parametrize("location", LOCATIONS)
 @pytest.mark.parametrize("year", YEARS)
 @pytest.mark.parametrize("scale", GEOGRAPHIC_SCALES)
-def test_svi_client_get_integration(location, year, scale):
+def test_svi_client_get_integration(location, year, scale, loop):
     client = SVIClient(enable_cache=False)
     df = client.get(location, scale, year)
     assert df.loc[0, "state_abbreviation"] == location
@@ -72,7 +72,7 @@ def test_svi_client_get_integration(location, year, scale):
 @pytest.mark.slow
 @pytest.mark.parametrize("year", YEARS)
 @pytest.mark.parametrize("scale", GEOGRAPHIC_SCALES)
-def test_svi_client_get_integration_us(year, scale):
+def test_svi_client_get_integration_us(year, scale, loop):
     client = SVIClient(enable_cache=False)
     df = client.get("us", scale, year)
     assert df.state_abbreviation.isin(LOCATIONS).all()


### PR DESCRIPTION
fixes #217

## Additions

- Adds `pytest-aiohttp` development dependency to `svi_client`

## Testing

1. Verified that this resolves locally `RuntimeError: There is no current event loop in thread 'MainThread'.` thrown in slow unit tests.

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
