### PR TITLE
Pin importlib-metadata version in nwm_client_new

### DIFF
--- a/python/nwm_client_new/setup.cfg
+++ b/python/nwm_client_new/setup.cfg
@@ -41,6 +41,8 @@ install_requires =
     aiofiles
     netcdf4
     tables
+    # remove when 3.7 support is dropped
+    importlib-metadata<=4.13.0
 python_requires = >=3.7
 include_package_data = True
 


### PR DESCRIPTION
Pin importlib-metadata<=4.13.0. Remove when 3.7 support dropped.

Fixes #211.

## Changes

- `nwm_client_new` dependency, `importlib-metadata` pinned to `<=4.13.0`


## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
