### PR TITLE
Bump _restclient's `aiohttp` and `aiohttp_client_cache` version deps

### DIFF
--- a/python/_restclient/pytest.ini
+++ b/python/_restclient/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/python/_restclient/setup.cfg
+++ b/python/_restclient/setup.cfg
@@ -30,8 +30,8 @@ packages = find_namespace:
 package_dir =
     =src
 install_requires =
-    aiohttp<=3.7.4.post0
-    aiohttp_client_cache
+    aiohttp~=3.8
+    aiohttp_client_cache[sqlite]>=0.9.0
     python-forge
     aiosqlite
     pandas


### PR DESCRIPTION
bump `aiohttp` and `aiohttp_client_cache` version deps
    
See #103 for background as to why `aiohttp` was previously pinned. In short, the issues that led to pinning `aiohttp` have be resolved upstream.
    
`aiohttp_client_cache` >= 0.9.0 needed b.c. https://github.com/requests-cache/aiohttp-client-cache/issues/173

## Changes

- `_restclient` depends on `aiohttp~=3.8` and `aiohttp_client_cache>=0.9.0`

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
