### PR TITLE
Update `NWMFileClient.py` concat method.

### DIFF
--- a/python/nwm_client_new/src/hydrotools/nwm_client_new/NWMFileClient.py
+++ b/python/nwm_client_new/src/hydrotools/nwm_client_new/NWMFileClient.py
@@ -288,7 +288,8 @@ class NWMFileClient(NWMClient):
                 warnings.warn(message, RuntimeWarning)
 
         # Concatenate
-        data = dd.multi.concat(dfs)
+        # data = dd.multi.concat(dfs)
+        data = dd.concat(dfs)
 
         # Convert units
         if self.unit_system == MeasurementUnitSystem.US:


### PR DESCRIPTION
The `dask.dataframe.multi.concat` method started raising errors in Python 3.12. Switching to vanilla `dask.dataframe.concat` seems to fix the issue.

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
