### PR TITLE
Add nwis_client iv context handler

### DIFF
--- a/python/nwis_client/src/hydrotools/nwis_client/iv.py
+++ b/python/nwis_client/src/hydrotools/nwis_client/iv.py
@@ -118,6 +118,12 @@ class IVDataService:
         )
         self._value_time_label = value_time_label
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self._restclient.close()
+
     @verify_case_insensitive_kwargs(handler=_verify_case_insensitive_kwargs_handler)
     def get(
         self,

--- a/python/nwis_client/tests/test_nwis.py
+++ b/python/nwis_client/tests/test_nwis.py
@@ -87,7 +87,7 @@ def wrap_iv_cache_location_to_temp(loop):
 
         o = partial(iv.IVDataService, cache_filename=cache_file)
         return o
-    
+
 
 @pytest.fixture
 def setup_iv(IVDataServiceWithTempCache):
@@ -119,7 +119,7 @@ def mocked_iv(mock_iv, setup_iv):
     `iv.IVDataService`'s `get_raw` method has been mocked to return an empty list.
     """
     return setup_iv
-    
+
 
 simplify_variable_test_data = [
     ("test", ",", "test"),
@@ -555,6 +555,17 @@ def test_nwis_client_cache_path(loop):
 
         # close resources
         service._restclient.close()
+
+
+@pytest.mark.slow
+def test_nwis_client_context_manager(loop):
+    """verify that context manager closes resources"""
+    with iv.IVDataService() as service:
+        service.get(sites=["01189000"], startDT="2022-01-01")
+    assert service._restclient._session.closed
+    # should this be closed? The assertion fails if uncommented
+    # assert service._restclient._loop.is_closed()
+
 
 def test_fixes_209(loop, monkeypatch):
     """


### PR DESCRIPTION
When using the IVDataService class to get usgs data, the rest client threads keep running after the main program has finished executing.

I managed to "fix" it by adding a context handler, but I'm not familiar enough with asyncio to make it work without the `with` syntax. 

## Test
```python
from hydrotools.nwis_client import IVDataService
service = IVDataService()
print("getting data")
usgs_data = service.get(sites="10154200", startDT="2001-01-01", endDT="2001-01-02")
print("done, exiting")
exit(1)
# Console doesn't return until I hit Ctrl+C
```
```console
getting data
done, exiting
^CException ignored in: <module 'threading' from '/usr/lib/python3.12/threading.py'>
Traceback (most recent call last):
  File "/usr/lib/python3.12/threading.py", line 1622, in _shutdown
    lock.acquire()
KeyboardInterrupt: 
^C
```
## Fix
```python
from hydrotools.nwis_client import IVDataService
with IVDataService() as service:
    print("getting data")
    usgs_data = service.get(sites="10154200", startDT="2001-01-01", endDT="2001-01-02")
    print("done, exiting")
    exit(1)
```
```console
getting data
done, exiting
```

## Note
To clarify: This does not entirely fix the original issue, the threads will not close unless you use the with context handler. The "test" code will cause the bug with and without this change. 