### PR TITLE
remove 3.8 and 3.9 testing from events

### DIFF
--- a/.github/workflows/run_slow_unit_tests.yml
+++ b/.github/workflows/run_slow_unit_tests.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Fixes failing long tests.