### PR TITLE
Update `_restclient` asyncio testing syntax

### DIFF
--- a/python/_restclient/tests/test_client.py
+++ b/python/_restclient/tests/test_client.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import pytest
 from aiohttp import web
+import asyncio
 
 from hydrotools._restclient.async_client import ClientSession
 
@@ -81,12 +82,13 @@ async def test_get_check_cache(basic_test_server):
         assert r.from_cache is False
         assert r2.from_cache is True
 
-
-def test_get_non_async(basic_test_server, event_loop):
+@pytest.mark.asyncio
+async def test_get_non_async(basic_test_server):
+    event_loop = asyncio.get_running_loop()
     session = ClientSession(loop=event_loop)
-    resp_coro = session.get(basic_test_server["uri"])
-    resp = event_loop.run_until_complete(resp_coro)
-    assert event_loop.run_until_complete(resp.json()) == basic_test_server["data"]
+    resp_coro = await session.get(basic_test_server["uri"])
+    resp = await resp_coro.json()
+    assert resp  == basic_test_server["data"]
 
 
 @pytest.fixture

--- a/python/_restclient/tests/test_restclient.py
+++ b/python/_restclient/tests/test_restclient.py
@@ -1,5 +1,6 @@
 from aiohttp import web
 import pytest
+import asyncio
 from hydrotools._restclient import RestClient
 
 
@@ -142,11 +143,10 @@ def test_get_headers_have_precedent_over_instance(basic_test_server):
         # verify in key, "some", "other_header" value in headers not "headers"
         assert all(k_v_pair in r.headers.items() for k_v_pair in method_headers.items())
 
-
-def test_build_url(event_loop):
+def test_build_url():
     base_url = "http://www.test.gov/"
     query_params = {"key": "value"}
-    with RestClient(enable_cache=False, loop=event_loop) as client:
+    with RestClient(enable_cache=False) as client:
 
         assert client.build_url(base_url) == base_url
         assert client.build_url(base_url, query_params) == f"{base_url}?key=value"
@@ -155,10 +155,11 @@ def test_build_url(event_loop):
 class ModuleFoundError(Exception):
     ...
 
-
-def test_restclient_nest_asyncio_ModuleNotFoundError(event_loop):
+@pytest.mark.asyncio
+async def test_restclient_nest_asyncio_ModuleNotFoundError():
     """Test for #99. Ensure ModuleNotFoundError raised if `nest_asyncio` not installed"""
-    import asyncio
+    event_loop = asyncio.get_running_loop()
+    # import asyncio
     import warnings
 
     # verify `nest_asyncio` is not installed
@@ -183,4 +184,4 @@ def test_restclient_nest_asyncio_ModuleNotFoundError(event_loop):
                 # this test will need to change if `nest_asyncio` becomes a requirement
                 RestClient(enable_cache=False)
 
-    event_loop.run_until_complete(test())
+    await test()

--- a/python/_restclient/tests/test_urllib.py
+++ b/python/_restclient/tests/test_urllib.py
@@ -204,7 +204,6 @@ def test_plus():
     base_url = "http://www.fake.gov"
     params = {"key": "+12"}
     url = Url(base_url, quote_treatment=Quote.QUOTE) + params
-    # print(url.quote_url)
 
 
 def test_quote_overide_map():

--- a/python/_restclient/tests/test_urllib.py
+++ b/python/_restclient/tests/test_urllib.py
@@ -204,7 +204,7 @@ def test_plus():
     base_url = "http://www.fake.gov"
     params = {"key": "+12"}
     url = Url(base_url, quote_treatment=Quote.QUOTE) + params
-    print(url.quote_url)
+    # print(url.quote_url)
 
 
 def test_quote_overide_map():


### PR DESCRIPTION
Updates (yet again) the `event_loop` syntax in the _restclient tests.

https://pytest-asyncio.readthedocs.io/en/stable/how-to-guides/migrate_from_0_21.html

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
