### PR TITLE
Add `waterdata-client` dataframe transformers

### DIFF
--- a/python/waterdata_client/README.md
+++ b/python/waterdata_client/README.md
@@ -27,7 +27,6 @@ The following example demonstrates how one might use `hydrotools.waterdata_clien
 ### Code
 
 ```python
-import geopandas as gpd
 from hydrotools.waterdata_client import LatestContinuousClient
 from hydrotools.waterdata_client.transformers import to_geodataframe
 

--- a/python/waterdata_client/README.md
+++ b/python/waterdata_client/README.md
@@ -27,20 +27,19 @@ The following example demonstrates how one might use `hydrotools.waterdata_clien
 ### Code
 
 ```python
-# Import client and geopandas for easy parsing
 import geopandas as gpd
 from hydrotools.waterdata_client import LatestContinuousClient
+from hydrotools.waterdata_client.transformers import to_geodataframe
 
 # Instantiate client
-client = LatestContinuousClient()
+client = LatestContinuousClient(transformer=to_geodataframe)
 
 # Retrieve data
-data = client.get(
+observations = client.get(
     monitoring_location_id="USGS-02146470"
     )
 
 # Look at values
-observations = gpd.GeoDataFrame.from_features(data[0])
 print(observations)
 print(observations.columns)
 ```
@@ -48,14 +47,14 @@ print(observations.columns)
 ### Output
 
 ```console
-                     geometry                                    id                    time_series_id  ... approval_status qualifier                     last_modified
-0  POINT (-80.85306 35.16444)  1b39aa0f-6adb-40ea-ab4e-453f88b8b16c  6ec29c85c72246ea83912c6f02f6fd63  ...     Provisional      None  2026-04-24T16:06:22.291045+00:00
-1  POINT (-80.85306 35.16444)  b3ce8113-2a1a-4d13-9d88-8a0237c11df6  27d30d4d1a4749bb887d1435da9fd278  ...     Provisional      None  2026-04-24T16:06:35.455215+00:00
-2  POINT (-80.85306 35.16444)  e56f5a19-8a93-489d-a2a0-98cae31f9529  b1f149deee984fcea8768c17076b1d7f  ...     Provisional      None  2026-04-24T16:06:17.732760+00:00
+                     geometry                                    id                    time_series_id  ... approval_status qualifiers                     last_modified
+0  POINT (-80.85306 35.16444)  3373c03d-ef10-41b9-be8f-afcd1511dc27  27d30d4d1a4749bb887d1435da9fd278  ...     Provisional       None  2026-05-01T15:47:32.759180+00:00
+1  POINT (-80.85306 35.16444)  48ba1d22-3278-449f-b767-a08f3ccffb2c  b1f149deee984fcea8768c17076b1d7f  ...     Provisional       None  2026-05-01T15:52:15.484900+00:00
+2  POINT (-80.85306 35.16444)  c387f069-f5f4-4954-8810-38b1ad3ba1ab  6ec29c85c72246ea83912c6f02f6fd63  ...     Provisional       None  2026-05-01T15:52:20.586492+00:00
 
 [3 rows x 12 columns]
-Index(['geometry', 'id', 'time_series_id', 'monitoring_location_id',
-       'parameter_code', 'statistic_id', 'time', 'value', 'unit_of_measure',
-       'approval_status', 'qualifier', 'last_modified'],
+Index(['geometry', 'id', 'time_series_id', 'usgs_site_code', 'parameter_code',
+       'statistic_id', 'value_time', 'value', 'measurement_unit',
+       'approval_status', 'qualifiers', 'last_modified'],
       dtype='str')
 ```

--- a/python/waterdata_client/pyproject.toml
+++ b/python/waterdata_client/pyproject.toml
@@ -27,7 +27,8 @@ dependencies = [
     "platformdirs",
     "jsonref",
     "diskcache",
-    "PyYAML"
+    "PyYAML",
+    "geopandas"
 ]
 dynamic = ["version"]
 

--- a/python/waterdata_client/scripts/build_clients.py
+++ b/python/waterdata_client/scripts/build_clients.py
@@ -19,10 +19,11 @@ from pathlib import Path
 from datetime import datetime, UTC
 import click
 from jinja2 import Environment, FileSystemLoader
+from schema_extract import get_template_data
+
 from hydrotools.waterdata_client.schema import get_schema
 from hydrotools.waterdata_client.client_config import SETTINGS
 from hydrotools.waterdata_client._version import __version__
-from schema_extract import get_template_data
 
 @click.command()
 @click.argument("templates", type=click.Path(exists=True, file_okay=False,
@@ -88,7 +89,7 @@ def write_clients_module(
         lstrip_blocks=True
     )
 
-    # Render and save
+    # Render and save clients.py
     template = env.get_template(name=name)
     content = template.render(
         timestamp=timestamp,

--- a/python/waterdata_client/scripts/schema_extract.py
+++ b/python/waterdata_client/scripts/schema_extract.py
@@ -3,7 +3,6 @@ import keyword
 import re
 from typing import Any, Optional, TypedDict
 import builtins
-from hydrotools.waterdata_client._version import __version__
 
 OPENAPI_TO_PYTHON_TYPES: dict[str, str] = {
     "string": "str",

--- a/python/waterdata_client/src/hydrotools/waterdata_client/base_client.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/base_client.py
@@ -184,7 +184,7 @@ class BaseClient(Generic[TransformedResponse_co]):
     def _handle_response(
             self,
             data: list[dict[str, Any]]
-    ) -> TransformedResponse_co:
+    ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Handle JSON response and optionally transform.
     
         Args:
@@ -195,5 +195,5 @@ class BaseClient(Generic[TransformedResponse_co]):
             transformed responses.
         """
         if self.transformer is None:
-            return data # type: ignore
+            return data
         return self.transformer(data)

--- a/python/waterdata_client/src/hydrotools/waterdata_client/base_client.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/base_client.py
@@ -19,9 +19,9 @@ from .url_builder import (
     build_request_batch_from_feature_ids,
     QueryType
 )
-from .transformers import TransformedResponse_co, ResponseTransformer, check_features
+from .transformers import TransformedResponseT_co, ResponseTransformer, check_features
 
-class BaseClient(Generic[TransformedResponse_co]):
+class BaseClient(Generic[TransformedResponseT_co]):
     """Base class for USGS OGC API clients. Specific child classes may overwrite
     private attributes: _server, _api, _endpoint, _path, _content_type,
     _max_pages.
@@ -49,7 +49,7 @@ class BaseClient(Generic[TransformedResponse_co]):
         max_retries: int = SETTINGS.default_retries,
         timeout_seconds: int = SETTINGS.timeout_seconds,
         ssl_context: Optional[ssl.SSLContext] = None,
-        transformer: Optional[ResponseTransformer[TransformedResponse_co]] = check_features
+        transformer: Optional[ResponseTransformer[TransformedResponseT_co]] = check_features
     ) -> None:
         self.concurrency_limit = concurrency_limit
         self.max_retries = max_retries
@@ -184,7 +184,7 @@ class BaseClient(Generic[TransformedResponse_co]):
     def _handle_response(
             self,
             data: list[dict[str, Any]]
-    ) -> TransformedResponse_co | list[dict[str, Any]]:
+    ) -> TransformedResponseT_co | list[dict[str, Any]]:
         """Handle JSON response and optionally transform.
     
         Args:

--- a/python/waterdata_client/src/hydrotools/waterdata_client/base_client.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/base_client.py
@@ -19,7 +19,7 @@ from .url_builder import (
     build_request_batch_from_feature_ids,
     QueryType
 )
-from .transformers import TransformedResponse_co, ResponseTransformer
+from .transformers import TransformedResponse_co, ResponseTransformer, check_features
 
 class BaseClient(Generic[TransformedResponse_co]):
     """Base class for USGS OGC API clients. Specific child classes may overwrite
@@ -33,7 +33,8 @@ class BaseClient(Generic[TransformedResponse_co]):
         timeout_seconds: Total request timeout in seconds.
         ssl_context: Custom SSL context for requests.
         transformer: Callable object that takes a list[dict[str, Any]] and returns
-            a transformed result. Defaults to GeoDataFrame.
+            a transformed result. Defaults to no transformation with validation
+            that some data were returned. Set to None to omit validation.
     """
     _server: URL = SETTINGS.usgs_base_url
     _api: OGCAPI = SETTINGS.default_api
@@ -48,7 +49,7 @@ class BaseClient(Generic[TransformedResponse_co]):
         max_retries: int = SETTINGS.default_retries,
         timeout_seconds: int = SETTINGS.timeout_seconds,
         ssl_context: Optional[ssl.SSLContext] = None,
-        transformer: Optional[ResponseTransformer] = None
+        transformer: Optional[ResponseTransformer[TransformedResponse_co]] = check_features
     ) -> None:
         self.concurrency_limit = concurrency_limit
         self.max_retries = max_retries
@@ -183,7 +184,7 @@ class BaseClient(Generic[TransformedResponse_co]):
     def _handle_response(
             self,
             data: list[dict[str, Any]]
-    ) -> list[dict[str, Any]] | TransformedResponse_co:
+    ) -> TransformedResponse_co:
         """Handle JSON response and optionally transform.
     
         Args:
@@ -194,5 +195,5 @@ class BaseClient(Generic[TransformedResponse_co]):
             transformed responses.
         """
         if self.transformer is None:
-            return data
+            return data # type: ignore
         return self.transformer(data)

--- a/python/waterdata_client/src/hydrotools/waterdata_client/base_client.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/base_client.py
@@ -19,7 +19,7 @@ from .url_builder import (
     build_request_batch_from_feature_ids,
     QueryType
 )
-from .transformers import TransformedResponse_co, ResponseTransformer, to_geodataframe
+from .transformers import TransformedResponse_co, ResponseTransformer
 
 class BaseClient(Generic[TransformedResponse_co]):
     """Base class for USGS OGC API clients. Specific child classes may overwrite
@@ -48,7 +48,7 @@ class BaseClient(Generic[TransformedResponse_co]):
         max_retries: int = SETTINGS.default_retries,
         timeout_seconds: int = SETTINGS.timeout_seconds,
         ssl_context: Optional[ssl.SSLContext] = None,
-        transformer: Optional[ResponseTransformer] = to_geodataframe
+        transformer: Optional[ResponseTransformer] = None
     ) -> None:
         self.concurrency_limit = concurrency_limit
         self.max_retries = max_retries

--- a/python/waterdata_client/src/hydrotools/waterdata_client/base_client.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/base_client.py
@@ -4,7 +4,7 @@ This module provides the base class for all collection-specific USGS OGC API
 clients. It handles configuration state and the low-level request pipeline.
 """
 import ssl
-from typing import Any, Optional, Sequence
+from typing import Any, Optional, Sequence, Generic
 from functools import partial
 
 from yarl import URL
@@ -19,8 +19,9 @@ from .url_builder import (
     build_request_batch_from_feature_ids,
     QueryType
 )
+from .transformers import TransformedResponse_co, ResponseTransformer, to_geodataframe
 
-class BaseClient:
+class BaseClient(Generic[TransformedResponse_co]):
     """Base class for USGS OGC API clients. Specific child classes may overwrite
     private attributes: _server, _api, _endpoint, _path, _content_type,
     _max_pages.
@@ -31,6 +32,8 @@ class BaseClient:
         max_retries: Number of times to attempt a failed request.
         timeout_seconds: Total request timeout in seconds.
         ssl_context: Custom SSL context for requests.
+        transformer: Callable object that takes a list[dict[str, Any]] and returns
+            a transformed result. Defaults to GeoDataFrame.
     """
     _server: URL = SETTINGS.usgs_base_url
     _api: OGCAPI = SETTINGS.default_api
@@ -44,12 +47,14 @@ class BaseClient:
         concurrency_limit: int = SETTINGS.default_concurrency,
         max_retries: int = SETTINGS.default_retries,
         timeout_seconds: int = SETTINGS.timeout_seconds,
-        ssl_context: Optional[ssl.SSLContext] = None
+        ssl_context: Optional[ssl.SSLContext] = None,
+        transformer: Optional[ResponseTransformer] = to_geodataframe
     ) -> None:
         self.concurrency_limit = concurrency_limit
         self.max_retries = max_retries
         self.timeout_seconds = timeout_seconds
         self.ssl_context = ssl_context
+        self.transformer = transformer
 
         # Setup request builder
         self._builder = partial(
@@ -174,3 +179,20 @@ class BaseClient:
             if link.get("rel") == "next":
                 return URL(link["href"])
         raise KeyError("response does not contain 'next' link")
+
+    def _handle_response(
+            self,
+            data: list[dict[str, Any]]
+    ) -> list[dict[str, Any]] | TransformedResponse_co:
+        """Handle JSON response and optionally transform.
+    
+        Args:
+            data: A list of deserialized GeoJSON responses from an OGC-compliant API.
+        
+        Returns:
+            If self.transformer is None, returns untransformed data, else returns
+            transformed responses.
+        """
+        if self.transformer is None:
+            return data
+        return self.transformer(data)

--- a/python/waterdata_client/src/hydrotools/waterdata_client/clients.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/clients.py
@@ -5,12 +5,12 @@ by inspecting the USGS OGC API JSON schema and identifying all "items" endpoints
 
 Package version: 0.8.0a0
 Generation script: build_clients.py
-Generated: 2026-04-29 14:54:35 Z
+Generated: 2026-04-29 18:12:04 Z
 JSON Schema source: https://api.waterdata.usgs.gov/ogcapi/v0/openapi?f=json
 JSON Schema version: 0.47.0
 OpenAPI version: 3.0.2
 """
-from typing import Any, Sequence, Literal, Optional
+from typing import Sequence, Literal, Optional
 from yarl import URL
 from .base_client import BaseClient
 from .constants import USGSCollection

--- a/python/waterdata_client/src/hydrotools/waterdata_client/clients.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/clients.py
@@ -5,9 +5,9 @@ by inspecting the USGS OGC API JSON schema and identifying all "items" endpoints
 
 Package version: 0.8.0a0
 Generation script: build_clients.py
-Generated: 2026-04-29 18:12:04 Z
+Generated: 2026-05-01 15:29:23 Z
 JSON Schema source: https://api.waterdata.usgs.gov/ogcapi/v0/openapi?f=json
-JSON Schema version: 0.47.0
+JSON Schema version: 0.49.2
 OpenAPI version: 3.0.2
 """
 from typing import Sequence, Literal, Optional
@@ -43,6 +43,7 @@ __all__ = [
     "MonitoringLocationsClient",
     "NationalAquiferCodesClient",
     "ParameterCodesClient",
+    "PeaksClient",
     "ReliabilityCodesClient",
     "SiteTypesClient",
     "StatesClient",
@@ -928,7 +929,7 @@ class CombinedMetadataClient(BaseClient[TransformedResponse_co]):
             bbox_crs: Indicates the coordinate reference system for the given bbox
                 coordinates.
             begin: The datetime of the earliest observation in the time series. Together
-                with `end`, this field represents the period of record of a time
+                with `end_utc`, this field represents the period of record of a time
                 series. Note that some time series may have large gaps in their
                 collection record.
                 You can query this field using date-times or intervals, adhering to
@@ -943,11 +944,12 @@ class CombinedMetadataClient(BaseClient[TransformedResponse_co]):
                   - Duration objects: "P1M" for data from the past month or "PT36H"
                 for the last 36 hours
 
-                Only features that have a `begin` that intersects the value of
+                Only features that have a `begin_utc` that intersects the value of
                 datetime are selected.
-            computation_identifier: Indicates whether the data from this time series represent a specific
-                statistical computation. Split parameters are enabled for this field,
-                so you can supply multiple values separated by commas.
+            computation_identifier: Indicates the computation performed to calculate this time series.
+                Values of "Instantaneous" reflect point measurements. Split parameters
+                are enabled for this field, so you can supply multiple values
+                separated by commas.
             construction_date: Date the well was completed.
             contributing_drainage_area: The contributing drainage area of a lake, stream, wetland, or estuary
                 monitoring location, in square miles. This item should be present only
@@ -971,7 +973,8 @@ class CombinedMetadataClient(BaseClient[TransformedResponse_co]):
                 ties/items).
             crs: Indicates the coordinate reference system for the results.
             data_type: The computational period type of data collected at the monitoring
-                location.
+                location. Split parameters are enabled for this field, so you can
+                supply multiple values separated by commas.
             depth_source_code: A code indicating the source of water-level data.
             district_code: The Water Science Centers (WSCs) across the United States use the FIPS
                 state code as the district code. In some case, monitoring locations
@@ -986,10 +989,10 @@ class CombinedMetadataClient(BaseClient[TransformedResponse_co]):
             end: The datetime of the most recent observation in the time series. Data
                 returned by this endpoint updates at most once per day, and
                 potentially less frequently than that, and as such there may be more
-                recent observations within a time series than the time series `end`
-                value reflects. Together with `begin`, this field represents the
-                period of record of a time series. It is additionally used to
-                determine whether a time series is "active".
+                recent observations within a time series than the time series
+                `end_utc` value reflects. Together with `begin_utc`, this field
+                represents the period of record of a time series. It is additionally
+                used to determine whether a time series is "active".
                 You can query this field using date-times or intervals, adhering to
                 RFC 3339, or using ISO 8601 duration objects. Intervals may be bounded
                 or half-bounded (double-dots at start or end).
@@ -1002,8 +1005,8 @@ class CombinedMetadataClient(BaseClient[TransformedResponse_co]):
                   - Duration objects: "P1M" for data from the past month or "PT36H"
                 for the last 36 hours
 
-                Only features that have a `end` that intersects the value of datetime
-                are selected.
+                Only features that have a `end_utc` that intersects the value of
+                datetime are selected.
             f: The optional f parameter indicates the output format which the server
                 shall provide as part of the response document.  The default format is
                 GeoJSON.
@@ -1209,8 +1212,11 @@ class CombinedMetadataClient(BaseClient[TransformedResponse_co]):
                 [https://api.waterdata.usgs.gov/ogcapi/v0/collections/altitude-datums/
                 items](https://api.waterdata.usgs.gov/ogcapi/v0/collections/altitude-
                 datums/items).
-            web_description: A description of what this time series represents, as used by WDFN and
-                other USGS data dissemination products.
+            web_description: An optional description of the time series. WDFN and other USGS data
+                dissemination products use this field, in combination with
+                sublocation_identifier, to distinguish the differences between
+                multiple time series for the same parameter code, statistic code, and
+                monitoring location.
             well_constructed_depth: The depth of the finished well, in feet below land surface datum.
                 Note: Not all groundwater monitoring locations have information on
                 Well Depth. Such monitoring locations will not be retrieved using this
@@ -2319,7 +2325,7 @@ class FieldMeasurementsClient(BaseClient[TransformedResponse_co]):
                 vertical axis (height or depth).
             bbox_crs: Indicates the coordinate reference system for the given bbox
                 coordinates.
-            control_condition: 
+            control_condition: The state of the control feature at the time of observation.
             crs: Indicates the coordinate reference system for the results.
             datetime: Either a date-time or an interval. Date and time expressions adhere to
                 RFC 3339.
@@ -2345,8 +2351,10 @@ class FieldMeasurementsClient(BaseClient[TransformedResponse_co]):
                 shall provide as part of the response document.  The default format is
                 GeoJSON.
             field_measurements_series_id: A unique identifier representing a single collection series. This
-                corresponds to the `id` field in the  `field-measurements-metadata`
-                endpoint.
+                corresponds to the `id` field in the `field-measurements-metadata`
+                endpoint. Collection series are defined as the set of field
+                measurements at a given monitoring location for a single parameter
+                code using a single reading type.
             field_visit_id: A universally unique identifier (UUID) for the field visit. Multiple
                 measurements may be made during a single field visit.
             lang: The optional lang parameter instructs the server return a response in
@@ -2377,7 +2385,7 @@ class FieldMeasurementsClient(BaseClient[TransformedResponse_co]):
                 datetime are selected.
             limit: The optional limit parameter limits the number of items that are
                 presented in the response document (maximum=50000, default=10).
-            measurement_rated: 
+            measurement_rated: A qualitative estimate of the quality of a measurement.
             measuring_agency: The agency performing the measurement.
             monitoring_location_id: A unique identifier representing a single monitoring location. This
                 corresponds to the `id` field in the `monitoring-locations` endpoint.
@@ -2416,9 +2424,9 @@ class FieldMeasurementsClient(BaseClient[TransformedResponse_co]):
                 of a record. It is not stable over time. Every time the record is
                 refreshed in our database (which may happen as part of normal
                 operations and does not imply any change to the data itself) a new ID
-                will be generated. To uniquely identify a single observation over
-                time, compare the `time` and `time_series_id` fields; each time series
-                will only have a single observation at a given `time`.
+                will be generated. There may be multiple readings occurring at
+                identical times during a single field visit; to uniquely identify a
+                set of readings over time, use the `field_visit_id` field.
             skipgeometry: This option can be used to skip response geometries for each feature.
             sortby: Specifies a comma-separated list of property names by which the
                 response shall be sorted.  If the property name is preceded by a plus
@@ -2539,7 +2547,7 @@ class FieldMeasurementsMetadataClient(BaseClient[TransformedResponse_co]):
             bbox_crs: Indicates the coordinate reference system for the given bbox
                 coordinates.
             begin: The datetime of the earliest observation in the time series. Together
-                with `end`, this field represents the period of record of a time
+                with `end_utc`, this field represents the period of record of a time
                 series. Note that some time series may have large gaps in their
                 collection record.
                 You can query this field using date-times or intervals, adhering to
@@ -2554,16 +2562,16 @@ class FieldMeasurementsMetadataClient(BaseClient[TransformedResponse_co]):
                   - Duration objects: "P1M" for data from the past month or "PT36H"
                 for the last 36 hours
 
-                Only features that have a `begin` that intersects the value of
+                Only features that have a `begin_utc` that intersects the value of
                 datetime are selected.
             crs: Indicates the coordinate reference system for the results.
             end: The datetime of the most recent observation in the time series. Data
                 returned by this endpoint updates at most once per day, and
                 potentially less frequently than that, and as such there may be more
-                recent observations within a time series than the time series `end`
-                value reflects. Together with `begin`, this field represents the
-                period of record of a time series. It is additionally used to
-                determine whether a time series is "active".
+                recent observations within a time series than the time series
+                `end_utc` value reflects. Together with `begin_utc`, this field
+                represents the period of record of a time series. It is additionally
+                used to determine whether a time series is "active".
                 You can query this field using date-times or intervals, adhering to
                 RFC 3339, or using ISO 8601 duration objects. Intervals may be bounded
                 or half-bounded (double-dots at start or end).
@@ -2576,8 +2584,8 @@ class FieldMeasurementsMetadataClient(BaseClient[TransformedResponse_co]):
                   - Duration objects: "P1M" for data from the past month or "PT36H"
                 for the last 36 hours
 
-                Only features that have a `end` that intersects the value of datetime
-                are selected.
+                Only features that have a `end_utc` that intersects the value of
+                datetime are selected.
             f: The optional f parameter indicates the output format which the server
                 shall provide as part of the response document.  The default format is
                 GeoJSON.
@@ -2639,13 +2647,11 @@ class FieldMeasurementsMetadataClient(BaseClient[TransformedResponse_co]):
 
                 Example: time_series_id IN ('64ee32f5350a4ec4967435dcd2e364ea',
                 '3e55d9c2d8a54bec9ca5e292b07d5a96')
-            query_id: A universally unique identifier (UUID) representing a single version
-                of a record. It is not stable over time. Every time the record is
-                refreshed in our database (which may happen as part of normal
-                operations and does not imply any change to the data itself) a new ID
-                will be generated. To uniquely identify a single observation over
-                time, compare the `time` and `time_series_id` fields; each time series
-                will only have a single observation at a given `time`.
+            query_id: A unique identifier representing a single collection series. This
+                corresponds to the `field_measurement_series_id` field in the `field-
+                measurements` endpoint. Collection series are defined as the set of
+                field measurements at a given monitoring location for a single
+                parameter code using a single reading type.
                  Split parameters are enabled for this field, so you can supply
                 multiple values separated by commas.
             skipgeometry: This option can be used to skip response geometries for each feature.
@@ -3946,16 +3952,24 @@ class MonitoringLocationsClient(BaseClient[TransformedResponse_co]):
                 Example: time_series_id IN ('64ee32f5350a4ec4967435dcd2e364ea',
                 '3e55d9c2d8a54bec9ca5e292b07d5a96')
             query_id: A unique identifier representing a single monitoring location. This
-                corresponds to the `id` field in the `monitoring-locations` endpoint.
+                corresponds to the `monitoring_location_id` field in other endpoints.
                 Monitoring location IDs are created by combining the agency code of
                 the agency responsible for the monitoring location (e.g. USGS) with
                 the ID number of the monitoring location (e.g. 02238500), separated by
                 a hyphen (e.g. USGS-02238500).
                  Split parameters are enabled for this field, so you can supply
                 multiple values separated by commas.
-            revision_created: 
-            revision_modified: 
-            revision_note: 
+            revision_created: The date a revision statement was created.
+            revision_modified: The most recent date a revision statement was modified.
+            revision_note: Approved water data are considered published record, but on occasion
+                changes or deletions (revisions) must be made to data after they are
+                approved. Data revisions are rare because of USGS quality assurance
+                practices, including documentation of all data before they are
+                officially approved. This field contains text explanations for data
+                revisions at this monitoring location. Changes to data also are
+                indicated with revision qualifier codes alongside the data. Text
+                explanations before 2017 are not necessarily available online, but can
+                be requested.
             site_type: A description of the hydrologic setting of the monitoring location. A
                 list of codes is available at
                 [https://api.waterdata.usgs.gov/ogcapi/v0/collections/site-types/items
@@ -4304,6 +4318,210 @@ class ParameterCodesClient(BaseClient[TransformedResponse_co]):
             "time_basis": time_basis,
             "unit_of_measure": unit_of_measure,
             "weight_basis": weight_basis,
+        }
+
+        # Ignore None
+        valid_query = {k: v for k, v in query.items() if v is not None}
+
+        # Get responses
+        data = self._get_json_responses(queries=[valid_query])
+
+        # Transform
+        return self._handle_response(data)
+
+class PeaksClient(BaseClient[TransformedResponse_co]):
+    """
+    Annual peak flow values are the maximum instantaneous streamflow
+    values recorded at a particular site for the entire water year from
+    October 1 to September 30. Note that the annual peak flow value may
+    not occur at the same time the maximum water level occurs due to
+    conditions such as backwater, tidal fluctuations, etc.
+    """
+    _endpoint = USGSCollection.PEAKS
+
+    def get(
+        self,
+        bbox: Optional[Sequence[float]] = None,
+        bbox_crs: Optional[URL] = None,
+        crs: Optional[URL] = None,
+        day: Optional[int] = None,
+        f: Optional[Literal["json", "html", "jsonld", "csv"]] = "json",
+        lang: Optional[Literal["en-US"]] = "en-US",
+        last_modified: Optional[str] = None,
+        limit: Optional[int] = 10,
+        monitoring_location_id: Optional[str] = None,
+        month: Optional[int] = None,
+        offset: Optional[int] = 0,
+        parameter_code: Optional[str] = None,
+        peak_since: Optional[int] = None,
+        properties: Optional[Sequence[Literal["time_series_id", "monitoring_location_id", "parameter_code", "id", "unit_of_measure", "value", "last_modified", "time", "water_year", "year", "month", "day", "time_of_day", "peak_since"]]] = None,
+        query_filter: Optional[str] = None,
+        query_id: Optional[str] = None,
+        skipgeometry: Optional[bool] = False,
+        sortby: Optional[Sequence[str]] = None,
+        time: Optional[str] = None,
+        time_of_day: Optional[str] = None,
+        time_series_id: Optional[str] = None,
+        unit_of_measure: Optional[str] = None,
+        value: Optional[str] = None,
+        water_year: Optional[int] = None,
+        year: Optional[int] = None,
+        ) -> TransformedResponse_co:
+        """Retrieve items from peaks.
+
+        Args:
+            bbox: Only features that have a geometry that intersects the bounding box
+                are selected.The bounding box is provided as four or six numbers,
+                depending on whether the coordinate reference system includes a
+                vertical axis (height or depth).
+            bbox_crs: Indicates the coordinate reference system for the given bbox
+                coordinates.
+            crs: Indicates the coordinate reference system for the results.
+            day: The day of the month a peak occurred. If null, the day a peak occurred
+                is unknown.
+                 Split parameters are enabled for this field, so you can supply
+                multiple values separated by commas.
+            f: The optional f parameter indicates the output format which the server
+                shall provide as part of the response document.  The default format is
+                GeoJSON.
+            lang: The optional lang parameter instructs the server return a response in
+                a certain language, if supported.  If the language is not among the
+                available values, the Accept-Language header language will be used if
+                it is supported. If the header is missing, the default server language
+                is used. Note that providers may only support a single language (or
+                often no language at all), that can be different from the server
+                language.  Language strings can be written in a complex (e.g. "fr-
+                CA,fr;q=0.9,en-US;q=0.8,en;q=0.7"), simple (e.g. "de") or locale-like
+                (e.g. "de-CH" or "fr_BE") fashion.
+            last_modified: The last time a record was refreshed in our database. This may happen
+                due to regular operational processes and does not necessarily indicate
+                anything about the measurement has changed.
+                You can query this field using date-times or intervals, adhering to
+                RFC 3339, or using ISO 8601 duration objects. Intervals may be bounded
+                or half-bounded (double-dots at start or end).
+                Examples:
+
+                  - A date-time: "2018-02-12T23:20:50Z"
+                  - A bounded interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
+                  - Half-bounded intervals: "2018-02-12T00:00:00Z/.." or
+                "../2018-03-18T12:31:12Z"
+                  - Duration objects: "P1M" for data from the past month or "PT36H"
+                for the last 36 hours
+
+                Only features that have a `last_modified` that intersects the value of
+                datetime are selected.
+            limit: The optional limit parameter limits the number of items that are
+                presented in the response document (maximum=50000, default=10).
+            monitoring_location_id: A unique identifier representing a single monitoring location. This
+                corresponds to the `id` field in the `monitoring-locations` endpoint.
+                Monitoring location IDs are created by combining the agency code of
+                the agency responsible for the monitoring location (e.g. USGS) with
+                the ID number of the monitoring location (e.g. 02238500), separated by
+                a hyphen (e.g. USGS-02238500).
+                 Split parameters are enabled for this field, so you can supply
+                multiple values separated by commas.
+            month: The calendar month a peak occurred. If null, the month a peak occurred
+                is unknown.
+                 Split parameters are enabled for this field, so you can supply
+                multiple values separated by commas.
+            offset: The optional offset parameter indicates the index within the result
+                set from which the server shall begin presenting results in the
+                response document.  The first element has an index of 0 (default).
+            parameter_code: Parameter codes are 5-digit codes used to identify the constituent
+                measured and the units of measure. A complete list of parameter codes
+                and associated groupings can be found at
+                [https://api.waterdata.usgs.gov/ogcapi/v0/collections/parameter-codes/
+                items](https://api.waterdata.usgs.gov/ogcapi/v0/collections/parameter-
+                codes/items).
+                 Split parameters are enabled for this field, so you can supply
+                multiple values separated by commas.
+            peak_since: If not null, this record represents the peak value for the parameter
+                code since the year contained in "peak_since".
+                 Split parameters are enabled for this field, so you can supply
+                multiple values separated by commas.
+            properties: The properties that should be included. The parameter value is a
+                comma-separated list of property names.
+            query_filter: CQL Text filter expression.  CQL JSON cannot be used here, only in the
+                body.
+                See also: https://docs.pygeoapi.io/en/latest/cql.html
+
+                Example: time_series_id IN ('64ee32f5350a4ec4967435dcd2e364ea',
+                '3e55d9c2d8a54bec9ca5e292b07d5a96')
+            query_id: Split parameters are enabled for this field, so you can supply
+                multiple values separated by commas.
+            skipgeometry: This option can be used to skip response geometries for each feature.
+            sortby: Specifies a comma-separated list of property names by which the
+                response shall be sorted.  If the property name is preceded by a plus
+                (+) sign it indicates an ascending sort for that property.  If the
+                property name is preceded by a minus (-) sign it indicates a
+                descending sort for that property.  If the property is not preceded by
+                a plus or minus, then the default sort order implied is ascending (+).
+
+                Only a single page of data can be returned when specifying sortby. If
+                you need more than a single page of data, don't specify a sortby value
+                and sort the full data set after it's been downloaded.
+            time: The date an observation represents. You can query this field using
+                date-times or intervals, adhering to RFC 3339, or using ISO 8601
+                duration objects. Intervals may be bounded or half-bounded (double-
+                dots at start or end).
+                Examples:
+
+                  - A date-time: "2018-02-12T23:20:50Z"
+                  - A bounded interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
+                  - Half-bounded intervals: "2018-02-12T00:00:00Z/.." or
+                "../2018-03-18T12:31:12Z"
+                  - Duration objects: "P1M" for data from the past month or "PT36H"
+                for the last 36 hours
+
+                Only features that have a `time` that intersects the value of datetime
+                are selected. If a feature has multiple temporal properties, it is the
+                decision of the server whether only a single temporal property is used
+                to determine the extent or all relevant temporal properties.
+            time_of_day: The time of day a peak occurred. If null, the time of day a peak
+                occurred is unknown.
+            time_series_id: A unique identifier representing a single time series. This
+                corresponds to the `id` field in the `time-series-metadata` endpoint.
+                 Split parameters are enabled for this field, so you can supply
+                multiple values separated by commas.
+            unit_of_measure: A human-readable description of the units of measurement associated
+                with an observation.
+            value: The value of the observation. Values are transmitted as strings in the
+                JSON response format in order to preserve precision.
+            water_year: The water year (running from October 1st to September 30th) a peak
+                occurred.
+                 Split parameters are enabled for this field, so you can supply
+                multiple values separated by commas.
+            year: The calendar year a peak occurred.
+                 Split parameters are enabled for this field, so you can supply
+                multiple values separated by commas.
+        """
+        # Translate Python parameters to API parameters
+        query = {
+            "bbox": bbox,
+            "bbox-crs": bbox_crs,
+            "crs": crs,
+            "day": day,
+            "f": f,
+            "lang": lang,
+            "last_modified": last_modified,
+            "limit": limit,
+            "monitoring_location_id": monitoring_location_id,
+            "month": month,
+            "offset": offset,
+            "parameter_code": parameter_code,
+            "peak_since": peak_since,
+            "properties": properties,
+            "filter": query_filter,
+            "id": query_id,
+            "skipGeometry": skipgeometry,
+            "sortby": sortby,
+            "time": time,
+            "time_of_day": time_of_day,
+            "time_series_id": time_series_id,
+            "unit_of_measure": unit_of_measure,
+            "value": value,
+            "water_year": water_year,
+            "year": year,
         }
 
         # Ignore None
@@ -4793,7 +5011,7 @@ class TimeSeriesMetadataClient(BaseClient[TransformedResponse_co]):
                 local time of the monitoring location. It is retained for backwards
                 compatibility, but will be removed in V1 of these APIs.
             begin_utc: The datetime of the earliest observation in the time series. Together
-                with `end`, this field represents the period of record of a time
+                with `end_utc`, this field represents the period of record of a time
                 series. Note that some time series may have large gaps in their
                 collection record.
                 You can query this field using date-times or intervals, adhering to
@@ -4808,11 +5026,12 @@ class TimeSeriesMetadataClient(BaseClient[TransformedResponse_co]):
                   - Duration objects: "P1M" for data from the past month or "PT36H"
                 for the last 36 hours
 
-                Only features that have a `begin` that intersects the value of
+                Only features that have a `begin_utc` that intersects the value of
                 datetime are selected.
-            computation_identifier: Indicates whether the data from this time series represent a specific
-                statistical computation. Split parameters are enabled for this field,
-                so you can supply multiple values separated by commas.
+            computation_identifier: Indicates the computation performed to calculate this time series.
+                Values of "Instantaneous" reflect point measurements. Split parameters
+                are enabled for this field, so you can supply multiple values
+                separated by commas.
             computation_period_identifier: Indicates the period of data used for any statistical computations.
                 Split parameters are enabled for this field, so you can supply
                 multiple values separated by commas.
@@ -4823,10 +5042,10 @@ class TimeSeriesMetadataClient(BaseClient[TransformedResponse_co]):
             end_utc: The datetime of the most recent observation in the time series. Data
                 returned by this endpoint updates at most once per day, and
                 potentially less frequently than that, and as such there may be more
-                recent observations within a time series than the time series `end`
-                value reflects. Together with `begin`, this field represents the
-                period of record of a time series. It is additionally used to
-                determine whether a time series is "active".
+                recent observations within a time series than the time series
+                `end_utc` value reflects. Together with `begin_utc`, this field
+                represents the period of record of a time series. It is additionally
+                used to determine whether a time series is "active".
                 You can query this field using date-times or intervals, adhering to
                 RFC 3339, or using ISO 8601 duration objects. Intervals may be bounded
                 or half-bounded (double-dots at start or end).
@@ -4839,8 +5058,8 @@ class TimeSeriesMetadataClient(BaseClient[TransformedResponse_co]):
                   - Duration objects: "P1M" for data from the past month or "PT36H"
                 for the last 36 hours
 
-                Only features that have a `end` that intersects the value of datetime
-                are selected.
+                Only features that have a `end_utc` that intersects the value of
+                datetime are selected.
             f: The optional f parameter indicates the output format which the server
                 shall provide as part of the response document.  The default format is
                 GeoJSON.
@@ -4927,9 +5146,9 @@ class TimeSeriesMetadataClient(BaseClient[TransformedResponse_co]):
                 Example: time_series_id IN ('64ee32f5350a4ec4967435dcd2e364ea',
                 '3e55d9c2d8a54bec9ca5e292b07d5a96')
             query_id: A unique identifier representing a single time series. This
-                corresponds to the `id` field in the `time-series-metadata` endpoint.
-                 Split parameters are enabled for this field, so you can supply
-                multiple values separated by commas.
+                corresponds to the "time_series_id" field in other endpoints. Split
+                parameters are enabled for this field, so you can supply multiple
+                values separated by commas.
             skipgeometry: This option can be used to skip response geometries for each feature.
             sortby: Specifies a comma-separated list of property names by which the
                 response shall be sorted.  If the property name is preceded by a plus
@@ -4960,8 +5179,11 @@ class TimeSeriesMetadataClient(BaseClient[TransformedResponse_co]):
                 sensor error, and therefore shouldn't be included in the time series.
             unit_of_measure: A human-readable description of the units of measurement associated
                 with an observation.
-            web_description: A description of what this time series represents, as used by WDFN and
-                other USGS data dissemination products.
+            web_description: An optional description of the time series. WDFN and other USGS data
+                dissemination products use this field, in combination with
+                sublocation_identifier, to distinguish the differences between
+                multiple time series for the same parameter code, statistic code, and
+                monitoring location.
         """
         # Translate Python parameters to API parameters
         query = {

--- a/python/waterdata_client/src/hydrotools/waterdata_client/clients.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/clients.py
@@ -3,9 +3,9 @@
 client classes for USGS OGC API items endpoints. These classes are generated
 by inspecting the USGS OGC API JSON schema and identifying all "items" endpoints.
 
-Package version: 0.8.0
+Package version: 0.8.0a0
 Generation script: build_clients.py
-Generated: 2026-04-24 15:52:44 Z
+Generated: 2026-04-29 12:26:54 Z
 JSON Schema source: https://api.waterdata.usgs.gov/ogcapi/v0/openapi?f=json
 JSON Schema version: 0.47.0
 OpenAPI version: 3.0.2
@@ -14,6 +14,7 @@ from typing import Any, Sequence, Literal, Optional
 from yarl import URL
 from .base_client import BaseClient
 from .constants import USGSCollection
+from .transformers import TransformedResponse_co
 
 __all__ = [
     "AgencyCodesClient",
@@ -51,7 +52,7 @@ __all__ = [
     "TopographicCodesClient",
 ]
 
-class AgencyCodesClient(BaseClient):
+class AgencyCodesClient(BaseClient[TransformedResponse_co]):
     """
     Code identifying the agency or organization used for site information,
     data sources, and permitting agencies. Agency codes are fixed values
@@ -74,7 +75,7 @@ class AgencyCodesClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from agency-codes.
 
         Args:
@@ -146,9 +147,12 @@ class AgencyCodesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class AltitudeDatumsClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class AltitudeDatumsClient(BaseClient[TransformedResponse_co]):
     """
     The recommended vertical datum is NAVD88 (North American Vertical
     Datum of 1988) where applicable as stated in Office of Information
@@ -175,7 +179,7 @@ class AltitudeDatumsClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from altitude-datums.
 
         Args:
@@ -247,9 +251,12 @@ class AltitudeDatumsClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class AquiferCodesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class AquiferCodesClient(BaseClient[TransformedResponse_co]):
     """
     Local aquifers in USGS data are identified by an aquifer name and
     geohydrologic unit code (a three-digit number related to the age of
@@ -283,7 +290,7 @@ class AquiferCodesClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from aquifer-codes.
 
         Args:
@@ -358,9 +365,12 @@ class AquiferCodesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class AquiferTypesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class AquiferTypesClient(BaseClient[TransformedResponse_co]):
     """
     Groundwater occurs in aquifers under two different conditions. Where
     water only partly fills an aquifer, the upper surface is free to rise
@@ -388,7 +398,7 @@ class AquiferTypesClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from aquifer-types.
 
         Args:
@@ -460,9 +470,12 @@ class AquiferTypesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class ChannelMeasurementsClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class ChannelMeasurementsClient(BaseClient[TransformedResponse_co]):
     """
     Channel measurements taken as part of streamflow field measurements.
     """
@@ -508,7 +521,7 @@ class ChannelMeasurementsClient(BaseClient):
         sortby: Optional[Sequence[str]] = None,
         time: Optional[str] = None,
         vertical_velocity_description: Optional[str] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from channel-measurements.
 
         Args:
@@ -696,9 +709,12 @@ class ChannelMeasurementsClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class CitationsClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class CitationsClient(BaseClient[TransformedResponse_co]):
     """
     Citations associated with water measurement methods.
     """
@@ -719,7 +735,7 @@ class CitationsClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from citations.
 
         Args:
@@ -792,9 +808,12 @@ class CitationsClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class CombinedMetadataClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class CombinedMetadataClient(BaseClient[TransformedResponse_co]):
     """
     This endpoint combines metadata from timeseries and field measurements
     collections by site.
@@ -870,7 +889,7 @@ class CombinedMetadataClient(BaseClient):
         vertical_datum_name: Optional[str] = None,
         web_description: Optional[str] = None,
         well_constructed_depth: Optional[float] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from combined-metadata.
 
         Args:
@@ -1272,9 +1291,12 @@ class CombinedMetadataClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class ContinuousClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class ContinuousClient(BaseClient[TransformedResponse_co]):
     """
     Continuous data are collected via automated sensors installed at a
     monitoring location. They are collected at a high frequency and often
@@ -1312,7 +1334,7 @@ class ContinuousClient(BaseClient):
         time_series_id: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from continuous.
 
         Args:
@@ -1488,9 +1510,12 @@ class ContinuousClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class CoordinateAccuracyCodesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class CoordinateAccuracyCodesClient(BaseClient[TransformedResponse_co]):
     """
     Appropriate code on the schedule to indicate the accuracy of the
     latitude-longitude values.
@@ -1512,7 +1537,7 @@ class CoordinateAccuracyCodesClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from coordinate-accuracy-codes.
 
         Args:
@@ -1584,9 +1609,12 @@ class CoordinateAccuracyCodesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class CoordinateDatumCodesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class CoordinateDatumCodesClient(BaseClient[TransformedResponse_co]):
     """
     Horizontal datum code for the latitude/longitude coordinates. There
     are currently more than 300 horizontal datums available for entry.
@@ -1608,7 +1636,7 @@ class CoordinateDatumCodesClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from coordinate-datum-codes.
 
         Args:
@@ -1680,9 +1708,12 @@ class CoordinateDatumCodesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class CoordinateMethodCodesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class CoordinateMethodCodesClient(BaseClient[TransformedResponse_co]):
     """
     Methods used to determine latitude-longitude values.
     """
@@ -1703,7 +1734,7 @@ class CoordinateMethodCodesClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from coordinate-method-codes.
 
         Args:
@@ -1775,9 +1806,12 @@ class CoordinateMethodCodesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class CountiesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class CountiesClient(BaseClient[TransformedResponse_co]):
     """
     The name of the county or county equivalent (parish, borough, planning
     reagion, etc.) in which the site is located. List includes Census
@@ -1803,7 +1837,7 @@ class CountiesClient(BaseClient):
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
         state_fips_code: Optional[str] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from counties.
 
         Args:
@@ -1884,9 +1918,12 @@ class CountiesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class CountriesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class CountriesClient(BaseClient[TransformedResponse_co]):
     """
     FIPS country codes and names.
     """
@@ -1907,7 +1944,7 @@ class CountriesClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from countries.
 
         Args:
@@ -1981,9 +2018,12 @@ class CountriesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class DailyClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class DailyClient(BaseClient[TransformedResponse_co]):
     """
     Daily data provide one data value to represent water conditions for
     the day. Throughout much of the history of the USGS, the primary water
@@ -2024,7 +2064,7 @@ class DailyClient(BaseClient):
         time_series_id: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from daily.
 
         Args:
@@ -2210,9 +2250,12 @@ class DailyClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class FieldMeasurementsClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class FieldMeasurementsClient(BaseClient[TransformedResponse_co]):
     """
     Field measurements are physically measured values collected during a
     visit to the monitoring location. Field measurements consist of
@@ -2255,7 +2298,7 @@ class FieldMeasurementsClient(BaseClient):
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
         vertical_datum: Optional[str] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from field-measurements.
 
         Args:
@@ -2451,9 +2494,12 @@ class FieldMeasurementsClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class FieldMeasurementsMetadataClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class FieldMeasurementsMetadataClient(BaseClient[TransformedResponse_co]):
     """
     This endpoint provides metadata about field measurement collections,
     including when the earliest and most recent observations for a
@@ -2482,7 +2528,7 @@ class FieldMeasurementsMetadataClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from field-measurements-metadata.
 
         Args:
@@ -2641,9 +2687,12 @@ class FieldMeasurementsMetadataClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class HydrologicUnitCodesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class HydrologicUnitCodesClient(BaseClient[TransformedResponse_co]):
     """
     Hydrologic units are geographic areas representing part or all of a
     surface drainage basin or distinct hydrologic feature identified by a
@@ -2673,7 +2722,7 @@ class HydrologicUnitCodesClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from hydrologic-unit-codes.
 
         Args:
@@ -2760,9 +2809,12 @@ class HydrologicUnitCodesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class LatestContinuousClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class LatestContinuousClient(BaseClient[TransformedResponse_co]):
     """
     This endpoint provides the most recent observation for each time
     series of continuous data. Continuous data are collected via automated
@@ -2803,7 +2855,7 @@ class LatestContinuousClient(BaseClient):
         time_series_id: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from latest-continuous.
 
         Args:
@@ -2987,9 +3039,12 @@ class LatestContinuousClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class LatestDailyClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class LatestDailyClient(BaseClient[TransformedResponse_co]):
     """
     Daily data provide one data value to represent water conditions for
     the day. Throughout much of the history of the USGS, the primary water
@@ -3030,7 +3085,7 @@ class LatestDailyClient(BaseClient):
         time_series_id: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from latest-daily.
 
         Args:
@@ -3216,9 +3271,12 @@ class LatestDailyClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class MediumCodesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class MediumCodesClient(BaseClient[TransformedResponse_co]):
     """
     Medium refers to the specific environmental medium from which the
     sample was collected. Medium type differs from site type because one
@@ -3244,7 +3302,7 @@ class MediumCodesClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from medium-codes.
 
         Args:
@@ -3332,9 +3390,12 @@ class MediumCodesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class MethodCategoriesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class MethodCategoriesClient(BaseClient[TransformedResponse_co]):
     """
     Categorical standards for methods describing the associated data's
     appropriateness for an intended use.
@@ -3357,7 +3418,7 @@ class MethodCategoriesClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from method-categories.
 
         Args:
@@ -3433,9 +3494,12 @@ class MethodCategoriesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class MethodCitationsClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class MethodCitationsClient(BaseClient[TransformedResponse_co]):
     """
     Citation identifiers for water measurement methods.
     """
@@ -3459,7 +3523,7 @@ class MethodCitationsClient(BaseClient):
         query_id: Optional[int] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from method-citations.
 
         Args:
@@ -3540,9 +3604,12 @@ class MethodCitationsClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class MethodsClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class MethodsClient(BaseClient[TransformedResponse_co]):
     """
     Water measurement or water-quality analytical methods. Codes and
     descriptions defining a method for calculating or measuring the value
@@ -3569,7 +3636,7 @@ class MethodsClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from methods.
 
         Args:
@@ -3648,9 +3715,12 @@ class MethodsClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class MonitoringLocationsClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class MonitoringLocationsClient(BaseClient[TransformedResponse_co]):
     """
     Location information is basic information about the monitoring
     location including the name, identifier, agency responsible for data
@@ -3717,7 +3787,7 @@ class MonitoringLocationsClient(BaseClient):
         vertical_datum: Optional[str] = None,
         vertical_datum_name: Optional[str] = None,
         well_constructed_depth: Optional[float] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from monitoring-locations.
 
         Args:
@@ -3999,9 +4069,12 @@ class MonitoringLocationsClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class NationalAquiferCodesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class NationalAquiferCodesClient(BaseClient[TransformedResponse_co]):
     """
     National aquifers are the principal aquifers or aquifer systems in the
     United States, defined as regionally extensive aquifers or aquifer
@@ -4025,7 +4098,7 @@ class NationalAquiferCodesClient(BaseClient):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from national-aquifer-codes.
 
         Args:
@@ -4097,9 +4170,12 @@ class NationalAquiferCodesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class ParameterCodesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class ParameterCodesClient(BaseClient[TransformedResponse_co]):
     """
     Parameter codes are 5-digit codes and associated descriptions used to
     identify the constituent measured and the units of measure. Some
@@ -4138,7 +4214,7 @@ class ParameterCodesClient(BaseClient):
         time_basis: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         weight_basis: Optional[str] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from parameter-codes.
 
         Args:
@@ -4234,9 +4310,12 @@ class ParameterCodesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class ReliabilityCodesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class ReliabilityCodesClient(BaseClient[TransformedResponse_co]):
     """
     Code indicating the reliability of the data available for the site.
     """
@@ -4257,7 +4336,7 @@ class ReliabilityCodesClient(BaseClient):
         reliability_description: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from reliability-codes.
 
         Args:
@@ -4329,9 +4408,12 @@ class ReliabilityCodesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class SiteTypesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class SiteTypesClient(BaseClient[TransformedResponse_co]):
     """
     The hydrologic cycle setting or a man-made feature thought to affect
     the hydrologic conditions measured at a site. Primary and secondary
@@ -4358,7 +4440,7 @@ class SiteTypesClient(BaseClient):
         site_type_primary_flag: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from site-types.
 
         Args:
@@ -4434,9 +4516,12 @@ class SiteTypesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class StatesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class StatesClient(BaseClient[TransformedResponse_co]):
     """
     State name or territory. Includes U.S. states and foreign entities
     classified under FIPS as 'Principal Administrative Divisions'.
@@ -4461,7 +4546,7 @@ class StatesClient(BaseClient):
         state_fips_code: Optional[str] = None,
         state_name: Optional[str] = None,
         state_postal_code: Optional[str] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from states.
 
         Args:
@@ -4542,9 +4627,12 @@ class StatesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class StatisticCodesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class StatisticCodesClient(BaseClient[TransformedResponse_co]):
     """
     Statistic codes.
     """
@@ -4566,7 +4654,7 @@ class StatisticCodesClient(BaseClient):
         sortby: Optional[Sequence[str]] = None,
         statistic_description: Optional[str] = None,
         statistic_name: Optional[str] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from statistic-codes.
 
         Args:
@@ -4640,9 +4728,12 @@ class StatisticCodesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class TimeSeriesMetadataClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class TimeSeriesMetadataClient(BaseClient[TransformedResponse_co]):
     """
     Daily data and continuous measurements are grouped into time series,
     which represent a collection of observations of a single parameter,
@@ -4688,7 +4779,7 @@ class TimeSeriesMetadataClient(BaseClient):
         thresholds: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         web_description: Optional[str] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from time-series-metadata.
 
         Args:
@@ -4912,9 +5003,12 @@ class TimeSeriesMetadataClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class TimeZoneCodesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class TimeZoneCodesClient(BaseClient[TransformedResponse_co]):
     """
     The ISO 8601 standard defines time zone offsets as a numerical value
     added to a local time to convert it to Coordinated Universal Time
@@ -4945,7 +5039,7 @@ class TimeZoneCodesClient(BaseClient):
         time_zone_description: Optional[str] = None,
         time_zone_name: Optional[str] = None,
         time_zone_utc_offset: Optional[str] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from time-zone-codes.
 
         Args:
@@ -5029,9 +5123,12 @@ class TimeZoneCodesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
 
-class TopographicCodesClient(BaseClient):
+        # Transform
+        return self._handle_response(data)
+
+class TopographicCodesClient(BaseClient[TransformedResponse_co]):
     """
     The code that best describes the topographic setting in which the site
     is located. Topographic setting refers to the geomorphic features in
@@ -5056,7 +5153,7 @@ class TopographicCodesClient(BaseClient):
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
         topography_name: Optional[str] = None,
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from topographic-codes.
 
         Args:
@@ -5132,5 +5229,8 @@ class TopographicCodesClient(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
+
+        # Transform
+        return self._handle_response(data)
 

--- a/python/waterdata_client/src/hydrotools/waterdata_client/clients.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/clients.py
@@ -5,7 +5,7 @@ by inspecting the USGS OGC API JSON schema and identifying all "items" endpoints
 
 Package version: 0.8.0a0
 Generation script: build_clients.py
-Generated: 2026-04-29 12:26:54 Z
+Generated: 2026-04-29 14:54:35 Z
 JSON Schema source: https://api.waterdata.usgs.gov/ogcapi/v0/openapi?f=json
 JSON Schema version: 0.47.0
 OpenAPI version: 3.0.2
@@ -75,7 +75,7 @@ class AgencyCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from agency-codes.
 
         Args:
@@ -179,7 +179,7 @@ class AltitudeDatumsClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from altitude-datums.
 
         Args:
@@ -290,7 +290,7 @@ class AquiferCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from aquifer-codes.
 
         Args:
@@ -398,7 +398,7 @@ class AquiferTypesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from aquifer-types.
 
         Args:
@@ -521,7 +521,7 @@ class ChannelMeasurementsClient(BaseClient[TransformedResponse_co]):
         sortby: Optional[Sequence[str]] = None,
         time: Optional[str] = None,
         vertical_velocity_description: Optional[str] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from channel-measurements.
 
         Args:
@@ -735,7 +735,7 @@ class CitationsClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from citations.
 
         Args:
@@ -889,7 +889,7 @@ class CombinedMetadataClient(BaseClient[TransformedResponse_co]):
         vertical_datum_name: Optional[str] = None,
         web_description: Optional[str] = None,
         well_constructed_depth: Optional[float] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from combined-metadata.
 
         Args:
@@ -1334,7 +1334,7 @@ class ContinuousClient(BaseClient[TransformedResponse_co]):
         time_series_id: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from continuous.
 
         Args:
@@ -1537,7 +1537,7 @@ class CoordinateAccuracyCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from coordinate-accuracy-codes.
 
         Args:
@@ -1636,7 +1636,7 @@ class CoordinateDatumCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from coordinate-datum-codes.
 
         Args:
@@ -1734,7 +1734,7 @@ class CoordinateMethodCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from coordinate-method-codes.
 
         Args:
@@ -1837,7 +1837,7 @@ class CountiesClient(BaseClient[TransformedResponse_co]):
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
         state_fips_code: Optional[str] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from counties.
 
         Args:
@@ -1944,7 +1944,7 @@ class CountriesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from countries.
 
         Args:
@@ -2064,7 +2064,7 @@ class DailyClient(BaseClient[TransformedResponse_co]):
         time_series_id: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from daily.
 
         Args:
@@ -2298,7 +2298,7 @@ class FieldMeasurementsClient(BaseClient[TransformedResponse_co]):
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
         vertical_datum: Optional[str] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from field-measurements.
 
         Args:
@@ -2528,7 +2528,7 @@ class FieldMeasurementsMetadataClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from field-measurements-metadata.
 
         Args:
@@ -2722,7 +2722,7 @@ class HydrologicUnitCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from hydrologic-unit-codes.
 
         Args:
@@ -2855,7 +2855,7 @@ class LatestContinuousClient(BaseClient[TransformedResponse_co]):
         time_series_id: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from latest-continuous.
 
         Args:
@@ -3085,7 +3085,7 @@ class LatestDailyClient(BaseClient[TransformedResponse_co]):
         time_series_id: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from latest-daily.
 
         Args:
@@ -3302,7 +3302,7 @@ class MediumCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from medium-codes.
 
         Args:
@@ -3418,7 +3418,7 @@ class MethodCategoriesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from method-categories.
 
         Args:
@@ -3523,7 +3523,7 @@ class MethodCitationsClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[int] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from method-citations.
 
         Args:
@@ -3636,7 +3636,7 @@ class MethodsClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from methods.
 
         Args:
@@ -3787,7 +3787,7 @@ class MonitoringLocationsClient(BaseClient[TransformedResponse_co]):
         vertical_datum: Optional[str] = None,
         vertical_datum_name: Optional[str] = None,
         well_constructed_depth: Optional[float] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from monitoring-locations.
 
         Args:
@@ -4098,7 +4098,7 @@ class NationalAquiferCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from national-aquifer-codes.
 
         Args:
@@ -4214,7 +4214,7 @@ class ParameterCodesClient(BaseClient[TransformedResponse_co]):
         time_basis: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         weight_basis: Optional[str] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from parameter-codes.
 
         Args:
@@ -4336,7 +4336,7 @@ class ReliabilityCodesClient(BaseClient[TransformedResponse_co]):
         reliability_description: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from reliability-codes.
 
         Args:
@@ -4440,7 +4440,7 @@ class SiteTypesClient(BaseClient[TransformedResponse_co]):
         site_type_primary_flag: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from site-types.
 
         Args:
@@ -4546,7 +4546,7 @@ class StatesClient(BaseClient[TransformedResponse_co]):
         state_fips_code: Optional[str] = None,
         state_name: Optional[str] = None,
         state_postal_code: Optional[str] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from states.
 
         Args:
@@ -4654,7 +4654,7 @@ class StatisticCodesClient(BaseClient[TransformedResponse_co]):
         sortby: Optional[Sequence[str]] = None,
         statistic_description: Optional[str] = None,
         statistic_name: Optional[str] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from statistic-codes.
 
         Args:
@@ -4779,7 +4779,7 @@ class TimeSeriesMetadataClient(BaseClient[TransformedResponse_co]):
         thresholds: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         web_description: Optional[str] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from time-series-metadata.
 
         Args:
@@ -5039,7 +5039,7 @@ class TimeZoneCodesClient(BaseClient[TransformedResponse_co]):
         time_zone_description: Optional[str] = None,
         time_zone_name: Optional[str] = None,
         time_zone_utc_offset: Optional[str] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from time-zone-codes.
 
         Args:
@@ -5153,7 +5153,7 @@ class TopographicCodesClient(BaseClient[TransformedResponse_co]):
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
         topography_name: Optional[str] = None,
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from topographic-codes.
 
         Args:

--- a/python/waterdata_client/src/hydrotools/waterdata_client/clients.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/clients.py
@@ -5,7 +5,7 @@ by inspecting the USGS OGC API JSON schema and identifying all "items" endpoints
 
 Package version: 0.8.0a0
 Generation script: build_clients.py
-Generated: 2026-05-01 15:29:23 Z
+Generated: 2026-05-01 17:52:23 Z
 JSON Schema source: https://api.waterdata.usgs.gov/ogcapi/v0/openapi?f=json
 JSON Schema version: 0.49.2
 OpenAPI version: 3.0.2
@@ -14,7 +14,7 @@ from typing import Sequence, Literal, Optional
 from yarl import URL
 from .base_client import BaseClient
 from .constants import USGSCollection
-from .transformers import TransformedResponse_co
+from .transformers import TransformedResponseT_co
 
 __all__ = [
     "AgencyCodesClient",
@@ -53,7 +53,7 @@ __all__ = [
     "TopographicCodesClient",
 ]
 
-class AgencyCodesClient(BaseClient[TransformedResponse_co]):
+class AgencyCodesClient(BaseClient[TransformedResponseT_co]):
     """
     Code identifying the agency or organization used for site information,
     data sources, and permitting agencies. Agency codes are fixed values
@@ -76,7 +76,7 @@ class AgencyCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from agency-codes.
 
         Args:
@@ -153,7 +153,7 @@ class AgencyCodesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class AltitudeDatumsClient(BaseClient[TransformedResponse_co]):
+class AltitudeDatumsClient(BaseClient[TransformedResponseT_co]):
     """
     The recommended vertical datum is NAVD88 (North American Vertical
     Datum of 1988) where applicable as stated in Office of Information
@@ -180,7 +180,7 @@ class AltitudeDatumsClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from altitude-datums.
 
         Args:
@@ -257,7 +257,7 @@ class AltitudeDatumsClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class AquiferCodesClient(BaseClient[TransformedResponse_co]):
+class AquiferCodesClient(BaseClient[TransformedResponseT_co]):
     """
     Local aquifers in USGS data are identified by an aquifer name and
     geohydrologic unit code (a three-digit number related to the age of
@@ -291,7 +291,7 @@ class AquiferCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from aquifer-codes.
 
         Args:
@@ -371,7 +371,7 @@ class AquiferCodesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class AquiferTypesClient(BaseClient[TransformedResponse_co]):
+class AquiferTypesClient(BaseClient[TransformedResponseT_co]):
     """
     Groundwater occurs in aquifers under two different conditions. Where
     water only partly fills an aquifer, the upper surface is free to rise
@@ -399,7 +399,7 @@ class AquiferTypesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from aquifer-types.
 
         Args:
@@ -476,7 +476,7 @@ class AquiferTypesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class ChannelMeasurementsClient(BaseClient[TransformedResponse_co]):
+class ChannelMeasurementsClient(BaseClient[TransformedResponseT_co]):
     """
     Channel measurements taken as part of streamflow field measurements.
     """
@@ -522,7 +522,7 @@ class ChannelMeasurementsClient(BaseClient[TransformedResponse_co]):
         sortby: Optional[Sequence[str]] = None,
         time: Optional[str] = None,
         vertical_velocity_description: Optional[str] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from channel-measurements.
 
         Args:
@@ -715,7 +715,7 @@ class ChannelMeasurementsClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class CitationsClient(BaseClient[TransformedResponse_co]):
+class CitationsClient(BaseClient[TransformedResponseT_co]):
     """
     Citations associated with water measurement methods.
     """
@@ -736,7 +736,7 @@ class CitationsClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from citations.
 
         Args:
@@ -814,7 +814,7 @@ class CitationsClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class CombinedMetadataClient(BaseClient[TransformedResponse_co]):
+class CombinedMetadataClient(BaseClient[TransformedResponseT_co]):
     """
     This endpoint combines metadata from timeseries and field measurements
     collections by site.
@@ -890,7 +890,7 @@ class CombinedMetadataClient(BaseClient[TransformedResponse_co]):
         vertical_datum_name: Optional[str] = None,
         web_description: Optional[str] = None,
         well_constructed_depth: Optional[float] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from combined-metadata.
 
         Args:
@@ -1302,7 +1302,7 @@ class CombinedMetadataClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class ContinuousClient(BaseClient[TransformedResponse_co]):
+class ContinuousClient(BaseClient[TransformedResponseT_co]):
     """
     Continuous data are collected via automated sensors installed at a
     monitoring location. They are collected at a high frequency and often
@@ -1340,7 +1340,7 @@ class ContinuousClient(BaseClient[TransformedResponse_co]):
         time_series_id: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from continuous.
 
         Args:
@@ -1521,7 +1521,7 @@ class ContinuousClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class CoordinateAccuracyCodesClient(BaseClient[TransformedResponse_co]):
+class CoordinateAccuracyCodesClient(BaseClient[TransformedResponseT_co]):
     """
     Appropriate code on the schedule to indicate the accuracy of the
     latitude-longitude values.
@@ -1543,7 +1543,7 @@ class CoordinateAccuracyCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from coordinate-accuracy-codes.
 
         Args:
@@ -1620,7 +1620,7 @@ class CoordinateAccuracyCodesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class CoordinateDatumCodesClient(BaseClient[TransformedResponse_co]):
+class CoordinateDatumCodesClient(BaseClient[TransformedResponseT_co]):
     """
     Horizontal datum code for the latitude/longitude coordinates. There
     are currently more than 300 horizontal datums available for entry.
@@ -1642,7 +1642,7 @@ class CoordinateDatumCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from coordinate-datum-codes.
 
         Args:
@@ -1719,7 +1719,7 @@ class CoordinateDatumCodesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class CoordinateMethodCodesClient(BaseClient[TransformedResponse_co]):
+class CoordinateMethodCodesClient(BaseClient[TransformedResponseT_co]):
     """
     Methods used to determine latitude-longitude values.
     """
@@ -1740,7 +1740,7 @@ class CoordinateMethodCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from coordinate-method-codes.
 
         Args:
@@ -1817,7 +1817,7 @@ class CoordinateMethodCodesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class CountiesClient(BaseClient[TransformedResponse_co]):
+class CountiesClient(BaseClient[TransformedResponseT_co]):
     """
     The name of the county or county equivalent (parish, borough, planning
     reagion, etc.) in which the site is located. List includes Census
@@ -1843,7 +1843,7 @@ class CountiesClient(BaseClient[TransformedResponse_co]):
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
         state_fips_code: Optional[str] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from counties.
 
         Args:
@@ -1929,7 +1929,7 @@ class CountiesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class CountriesClient(BaseClient[TransformedResponse_co]):
+class CountriesClient(BaseClient[TransformedResponseT_co]):
     """
     FIPS country codes and names.
     """
@@ -1950,7 +1950,7 @@ class CountriesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from countries.
 
         Args:
@@ -2029,7 +2029,7 @@ class CountriesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class DailyClient(BaseClient[TransformedResponse_co]):
+class DailyClient(BaseClient[TransformedResponseT_co]):
     """
     Daily data provide one data value to represent water conditions for
     the day. Throughout much of the history of the USGS, the primary water
@@ -2070,7 +2070,7 @@ class DailyClient(BaseClient[TransformedResponse_co]):
         time_series_id: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from daily.
 
         Args:
@@ -2261,7 +2261,7 @@ class DailyClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class FieldMeasurementsClient(BaseClient[TransformedResponse_co]):
+class FieldMeasurementsClient(BaseClient[TransformedResponseT_co]):
     """
     Field measurements are physically measured values collected during a
     visit to the monitoring location. Field measurements consist of
@@ -2304,7 +2304,7 @@ class FieldMeasurementsClient(BaseClient[TransformedResponse_co]):
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
         vertical_datum: Optional[str] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from field-measurements.
 
         Args:
@@ -2507,7 +2507,7 @@ class FieldMeasurementsClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class FieldMeasurementsMetadataClient(BaseClient[TransformedResponse_co]):
+class FieldMeasurementsMetadataClient(BaseClient[TransformedResponseT_co]):
     """
     This endpoint provides metadata about field measurement collections,
     including when the earliest and most recent observations for a
@@ -2536,7 +2536,7 @@ class FieldMeasurementsMetadataClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from field-measurements-metadata.
 
         Args:
@@ -2698,7 +2698,7 @@ class FieldMeasurementsMetadataClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class HydrologicUnitCodesClient(BaseClient[TransformedResponse_co]):
+class HydrologicUnitCodesClient(BaseClient[TransformedResponseT_co]):
     """
     Hydrologic units are geographic areas representing part or all of a
     surface drainage basin or distinct hydrologic feature identified by a
@@ -2728,7 +2728,7 @@ class HydrologicUnitCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from hydrologic-unit-codes.
 
         Args:
@@ -2820,7 +2820,7 @@ class HydrologicUnitCodesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class LatestContinuousClient(BaseClient[TransformedResponse_co]):
+class LatestContinuousClient(BaseClient[TransformedResponseT_co]):
     """
     This endpoint provides the most recent observation for each time
     series of continuous data. Continuous data are collected via automated
@@ -2861,7 +2861,7 @@ class LatestContinuousClient(BaseClient[TransformedResponse_co]):
         time_series_id: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from latest-continuous.
 
         Args:
@@ -3050,7 +3050,7 @@ class LatestContinuousClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class LatestDailyClient(BaseClient[TransformedResponse_co]):
+class LatestDailyClient(BaseClient[TransformedResponseT_co]):
     """
     Daily data provide one data value to represent water conditions for
     the day. Throughout much of the history of the USGS, the primary water
@@ -3091,7 +3091,7 @@ class LatestDailyClient(BaseClient[TransformedResponse_co]):
         time_series_id: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         value: Optional[str] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from latest-daily.
 
         Args:
@@ -3282,7 +3282,7 @@ class LatestDailyClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class MediumCodesClient(BaseClient[TransformedResponse_co]):
+class MediumCodesClient(BaseClient[TransformedResponseT_co]):
     """
     Medium refers to the specific environmental medium from which the
     sample was collected. Medium type differs from site type because one
@@ -3308,7 +3308,7 @@ class MediumCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from medium-codes.
 
         Args:
@@ -3401,7 +3401,7 @@ class MediumCodesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class MethodCategoriesClient(BaseClient[TransformedResponse_co]):
+class MethodCategoriesClient(BaseClient[TransformedResponseT_co]):
     """
     Categorical standards for methods describing the associated data's
     appropriateness for an intended use.
@@ -3424,7 +3424,7 @@ class MethodCategoriesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from method-categories.
 
         Args:
@@ -3505,7 +3505,7 @@ class MethodCategoriesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class MethodCitationsClient(BaseClient[TransformedResponse_co]):
+class MethodCitationsClient(BaseClient[TransformedResponseT_co]):
     """
     Citation identifiers for water measurement methods.
     """
@@ -3529,7 +3529,7 @@ class MethodCitationsClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[int] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from method-citations.
 
         Args:
@@ -3615,7 +3615,7 @@ class MethodCitationsClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class MethodsClient(BaseClient[TransformedResponse_co]):
+class MethodsClient(BaseClient[TransformedResponseT_co]):
     """
     Water measurement or water-quality analytical methods. Codes and
     descriptions defining a method for calculating or measuring the value
@@ -3642,7 +3642,7 @@ class MethodsClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from methods.
 
         Args:
@@ -3726,7 +3726,7 @@ class MethodsClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class MonitoringLocationsClient(BaseClient[TransformedResponse_co]):
+class MonitoringLocationsClient(BaseClient[TransformedResponseT_co]):
     """
     Location information is basic information about the monitoring
     location including the name, identifier, agency responsible for data
@@ -3793,7 +3793,7 @@ class MonitoringLocationsClient(BaseClient[TransformedResponse_co]):
         vertical_datum: Optional[str] = None,
         vertical_datum_name: Optional[str] = None,
         well_constructed_depth: Optional[float] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from monitoring-locations.
 
         Args:
@@ -4088,7 +4088,7 @@ class MonitoringLocationsClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class NationalAquiferCodesClient(BaseClient[TransformedResponse_co]):
+class NationalAquiferCodesClient(BaseClient[TransformedResponseT_co]):
     """
     National aquifers are the principal aquifers or aquifer systems in the
     United States, defined as regionally extensive aquifers or aquifer
@@ -4112,7 +4112,7 @@ class NationalAquiferCodesClient(BaseClient[TransformedResponse_co]):
         query_id: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from national-aquifer-codes.
 
         Args:
@@ -4189,7 +4189,7 @@ class NationalAquiferCodesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class ParameterCodesClient(BaseClient[TransformedResponse_co]):
+class ParameterCodesClient(BaseClient[TransformedResponseT_co]):
     """
     Parameter codes are 5-digit codes and associated descriptions used to
     identify the constituent measured and the units of measure. Some
@@ -4228,7 +4228,7 @@ class ParameterCodesClient(BaseClient[TransformedResponse_co]):
         time_basis: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         weight_basis: Optional[str] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from parameter-codes.
 
         Args:
@@ -4329,7 +4329,7 @@ class ParameterCodesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class PeaksClient(BaseClient[TransformedResponse_co]):
+class PeaksClient(BaseClient[TransformedResponseT_co]):
     """
     Annual peak flow values are the maximum instantaneous streamflow
     values recorded at a particular site for the entire water year from
@@ -4366,7 +4366,7 @@ class PeaksClient(BaseClient[TransformedResponse_co]):
         value: Optional[str] = None,
         water_year: Optional[int] = None,
         year: Optional[int] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from peaks.
 
         Args:
@@ -4533,7 +4533,7 @@ class PeaksClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class ReliabilityCodesClient(BaseClient[TransformedResponse_co]):
+class ReliabilityCodesClient(BaseClient[TransformedResponseT_co]):
     """
     Code indicating the reliability of the data available for the site.
     """
@@ -4554,7 +4554,7 @@ class ReliabilityCodesClient(BaseClient[TransformedResponse_co]):
         reliability_description: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from reliability-codes.
 
         Args:
@@ -4631,7 +4631,7 @@ class ReliabilityCodesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class SiteTypesClient(BaseClient[TransformedResponse_co]):
+class SiteTypesClient(BaseClient[TransformedResponseT_co]):
     """
     The hydrologic cycle setting or a man-made feature thought to affect
     the hydrologic conditions measured at a site. Primary and secondary
@@ -4658,7 +4658,7 @@ class SiteTypesClient(BaseClient[TransformedResponse_co]):
         site_type_primary_flag: Optional[str] = None,
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from site-types.
 
         Args:
@@ -4739,7 +4739,7 @@ class SiteTypesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class StatesClient(BaseClient[TransformedResponse_co]):
+class StatesClient(BaseClient[TransformedResponseT_co]):
     """
     State name or territory. Includes U.S. states and foreign entities
     classified under FIPS as 'Principal Administrative Divisions'.
@@ -4764,7 +4764,7 @@ class StatesClient(BaseClient[TransformedResponse_co]):
         state_fips_code: Optional[str] = None,
         state_name: Optional[str] = None,
         state_postal_code: Optional[str] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from states.
 
         Args:
@@ -4850,7 +4850,7 @@ class StatesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class StatisticCodesClient(BaseClient[TransformedResponse_co]):
+class StatisticCodesClient(BaseClient[TransformedResponseT_co]):
     """
     Statistic codes.
     """
@@ -4872,7 +4872,7 @@ class StatisticCodesClient(BaseClient[TransformedResponse_co]):
         sortby: Optional[Sequence[str]] = None,
         statistic_description: Optional[str] = None,
         statistic_name: Optional[str] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from statistic-codes.
 
         Args:
@@ -4951,7 +4951,7 @@ class StatisticCodesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class TimeSeriesMetadataClient(BaseClient[TransformedResponse_co]):
+class TimeSeriesMetadataClient(BaseClient[TransformedResponseT_co]):
     """
     Daily data and continuous measurements are grouped into time series,
     which represent a collection of observations of a single parameter,
@@ -4997,7 +4997,7 @@ class TimeSeriesMetadataClient(BaseClient[TransformedResponse_co]):
         thresholds: Optional[str] = None,
         unit_of_measure: Optional[str] = None,
         web_description: Optional[str] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from time-series-metadata.
 
         Args:
@@ -5230,7 +5230,7 @@ class TimeSeriesMetadataClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class TimeZoneCodesClient(BaseClient[TransformedResponse_co]):
+class TimeZoneCodesClient(BaseClient[TransformedResponseT_co]):
     """
     The ISO 8601 standard defines time zone offsets as a numerical value
     added to a local time to convert it to Coordinated Universal Time
@@ -5261,7 +5261,7 @@ class TimeZoneCodesClient(BaseClient[TransformedResponse_co]):
         time_zone_description: Optional[str] = None,
         time_zone_name: Optional[str] = None,
         time_zone_utc_offset: Optional[str] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from time-zone-codes.
 
         Args:
@@ -5350,7 +5350,7 @@ class TimeZoneCodesClient(BaseClient[TransformedResponse_co]):
         # Transform
         return self._handle_response(data)
 
-class TopographicCodesClient(BaseClient[TransformedResponse_co]):
+class TopographicCodesClient(BaseClient[TransformedResponseT_co]):
     """
     The code that best describes the topographic setting in which the site
     is located. Topographic setting refers to the geomorphic features in
@@ -5375,7 +5375,7 @@ class TopographicCodesClient(BaseClient[TransformedResponse_co]):
         skipgeometry: Optional[bool] = False,
         sortby: Optional[Sequence[str]] = None,
         topography_name: Optional[str] = None,
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from topographic-codes.
 
         Args:

--- a/python/waterdata_client/src/hydrotools/waterdata_client/constants.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/constants.py
@@ -5,9 +5,9 @@ by inspecting the USGS OGC API JSON schema and identifying all "items" endpoints
 
 Package version: 0.8.0a0
 Generation script: build_constants.py
-Generated: 2026-04-29 18:15:52 Z
+Generated: 2026-05-01 15:29:03 Z
 JSON Schema source: https://api.waterdata.usgs.gov/ogcapi/v0/openapi?f=json
-JSON Schema version: 0.47.0
+JSON Schema version: 0.49.2
 OpenAPI version: 3.0.2
 """
 from enum import StrEnum
@@ -54,6 +54,7 @@ class USGSCollection(StrEnum):
     MONITORING_LOCATIONS = "monitoring-locations"
     NATIONAL_AQUIFER_CODES = "national-aquifer-codes"
     PARAMETER_CODES = "parameter-codes"
+    PEAKS = "peaks"
     RELIABILITY_CODES = "reliability-codes"
     SITE_TYPES = "site-types"
     STATES = "states"
@@ -89,14 +90,6 @@ class HydroToolsColumn(StrEnum):
     APPROVAL_STATUS = "approval_status"
     LAST_MODIFIED = "last_modified"
     GEO_FEATURE_ID = "geo_feature_id"
-
-CATEGORICAL_COLUMNS: list[HydroToolsColumn] = [
-    HydroToolsColumn.VARIABLE_NAME,
-    HydroToolsColumn.USGS_SITE_CODE,
-    HydroToolsColumn.MEASUREMENT_UNIT,
-    HydroToolsColumn.QUALIFIERS
-]
-"""List of columns to transform to categorical types."""
 
 HYDROTOOLS_DATAFRAME_COLUMN_MAPPING: dict[str, HydroToolsColumn] = {
     "properties.id": HydroToolsColumn.GEO_FEATURE_ID,

--- a/python/waterdata_client/src/hydrotools/waterdata_client/constants.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/constants.py
@@ -5,7 +5,7 @@ by inspecting the USGS OGC API JSON schema and identifying all "items" endpoints
 
 Package version: 0.8.0a0
 Generation script: build_constants.py
-Generated: 2026-04-29 17:29:45 Z
+Generated: 2026-04-29 18:08:03 Z
 JSON Schema source: https://api.waterdata.usgs.gov/ogcapi/v0/openapi?f=json
 JSON Schema version: 0.47.0
 OpenAPI version: 3.0.2
@@ -82,6 +82,13 @@ class HydroToolsColumn(StrEnum):
     USACE_GAUGE_ID = "usace_gauge_id"
     START = "start"
     END = "end"
+    ID = "id"
+    TIME_SERIES_ID = "time_series_id"
+    PARAMETER_CODE = "parameter_code"
+    STATISTIC_ID = "statistic_id"
+    APPROVAL_STATUS = "approval_status"
+    LAST_MODIFIED = "last_modified"
+    GEO_FEATURE_ID = "geo_feature_id"
 
 CATEGORICAL_COLUMNS: list[HydroToolsColumn] = [
     HydroToolsColumn.VARIABLE_NAME,
@@ -90,3 +97,19 @@ CATEGORICAL_COLUMNS: list[HydroToolsColumn] = [
     HydroToolsColumn.QUALIFIERS
 ]
 """List of columns to transform to categorical types."""
+
+HYDROTOOLS_DATAFRAME_COLUMN_MAPPING: dict[str, HydroToolsColumn] = {
+    "properties.id": HydroToolsColumn.GEO_FEATURE_ID,
+    "properties.time_series_id": HydroToolsColumn.TIME_SERIES_ID,
+    "properties.monitoring_location_id": HydroToolsColumn.USGS_SITE_CODE,
+    "properties.parameter_code": HydroToolsColumn.PARAMETER_CODE,
+    "properties.statistic_id": HydroToolsColumn.STATISTIC_ID,
+    "properties.time": HydroToolsColumn.VALUE_TIME,
+    "properties.value": HydroToolsColumn.VALUE,
+    "properties.unit_of_measure": HydroToolsColumn.MEASUREMENT_UNIT,
+    "properties.approval_status": HydroToolsColumn.APPROVAL_STATUS,
+    "properties.qualifier": HydroToolsColumn.QUALIFIERS,
+    "properties.last_modified": HydroToolsColumn.LAST_MODIFIED
+}
+"""Mapping from default pandas.json_normalize column names to HydroTools
+canonical column labels."""

--- a/python/waterdata_client/src/hydrotools/waterdata_client/constants.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/constants.py
@@ -3,9 +3,9 @@
 and constants used package-wide. The `USGSCollection` StrEnum is generated
 by inspecting the USGS OGC API JSON schema and identifying all "items" endpoints.
 
-Package version: 0.1.0
+Package version: 0.8.0a0
 Generation script: build_constants.py
-Generated: 2026-04-23 18:14:02 Z
+Generated: 2026-04-29 17:29:45 Z
 JSON Schema source: https://api.waterdata.usgs.gov/ogcapi/v0/openapi?f=json
 JSON Schema version: 0.47.0
 OpenAPI version: 3.0.2
@@ -61,3 +61,32 @@ class USGSCollection(StrEnum):
     TIME_SERIES_METADATA = "time-series-metadata"
     TIME_ZONE_CODES = "time-zone-codes"
     TOPOGRAPHIC_CODES = "topographic-codes"
+
+class HydroToolsColumn(StrEnum):
+    """Canonical HydroTools column labels."""
+    VALUE = "value"
+    VALUE_TIME = "value_time"
+    VARIABLE_NAME = "variable_name"
+    MEASUREMENT_UNIT = "measurement_unit"
+    QUALIFIERS = "qualifiers"
+    SERIES = "series"
+    CONFIGURATION = "configuration"
+    REFERENCE_TIME = "reference_time"
+    LONGITUDE = "longitude"
+    LATITUDE = "latitude"
+    CRS = "crs"
+    GEOMETRY = "geometry"
+    USGS_SITE_CODE = "usgs_site_code"
+    NWM_FEATURE_ID = "nwm_feature_id"
+    NWS_LID = "nws_lid"
+    USACE_GAUGE_ID = "usace_gauge_id"
+    START = "start"
+    END = "end"
+
+CATEGORICAL_COLUMNS: list[HydroToolsColumn] = [
+    HydroToolsColumn.VARIABLE_NAME,
+    HydroToolsColumn.USGS_SITE_CODE,
+    HydroToolsColumn.MEASUREMENT_UNIT,
+    HydroToolsColumn.QUALIFIERS
+]
+"""List of columns to transform to categorical types."""

--- a/python/waterdata_client/src/hydrotools/waterdata_client/constants.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/constants.py
@@ -5,7 +5,7 @@ by inspecting the USGS OGC API JSON schema and identifying all "items" endpoints
 
 Package version: 0.8.0a0
 Generation script: build_constants.py
-Generated: 2026-04-29 18:08:03 Z
+Generated: 2026-04-29 18:15:52 Z
 JSON Schema source: https://api.waterdata.usgs.gov/ogcapi/v0/openapi?f=json
 JSON Schema version: 0.47.0
 OpenAPI version: 3.0.2
@@ -109,7 +109,18 @@ HYDROTOOLS_DATAFRAME_COLUMN_MAPPING: dict[str, HydroToolsColumn] = {
     "properties.unit_of_measure": HydroToolsColumn.MEASUREMENT_UNIT,
     "properties.approval_status": HydroToolsColumn.APPROVAL_STATUS,
     "properties.qualifier": HydroToolsColumn.QUALIFIERS,
-    "properties.last_modified": HydroToolsColumn.LAST_MODIFIED
+    "properties.last_modified": HydroToolsColumn.LAST_MODIFIED,
+    "id": HydroToolsColumn.ID,
+    "time_series_id": HydroToolsColumn.TIME_SERIES_ID,
+    "monitoring_location_id": HydroToolsColumn.USGS_SITE_CODE,
+    "parameter_code": HydroToolsColumn.PARAMETER_CODE,
+    "statistic_id": HydroToolsColumn.STATISTIC_ID,
+    "time": HydroToolsColumn.VALUE_TIME,
+    "value": HydroToolsColumn.VALUE,
+    "unit_of_measure": HydroToolsColumn.MEASUREMENT_UNIT,
+    "approval_status": HydroToolsColumn.APPROVAL_STATUS,
+    "qualifier": HydroToolsColumn.QUALIFIERS,
+    "last_modified": HydroToolsColumn.LAST_MODIFIED
 }
 """Mapping from default pandas.json_normalize column names to HydroTools
 canonical column labels."""

--- a/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
@@ -6,8 +6,7 @@ from typing import Any, Protocol, TypeVar, runtime_checkable
 import pandas as pd
 import geopandas as gpd
 
-TransformedResponse_co = TypeVar("TransformedResponse_co",
-    default=list[dict[str, Any]], covariant=True)
+TransformedResponse_co = TypeVar("TransformedResponse_co", covariant=True)
 """Generic transformed response type for transformer methods."""
 
 class NoDataError(Exception):

--- a/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
@@ -1,10 +1,14 @@
 """Defines transformation methods for handling deserialized JSON responses from
 USGS OGC APIs.
 """
-from typing import Any, Protocol, TypeVar, runtime_checkable
+from typing import Any, Protocol, TypeVar, runtime_checkable, Optional
+from enum import StrEnum
 
 import pandas as pd
+from pandas._typing import Renamer
 import geopandas as gpd
+
+from .constants import HYDROTOOLS_DATAFRAME_COLUMN_MAPPING
 
 TransformedResponse_co = TypeVar("TransformedResponse_co", covariant=True)
 """Generic transformed response type for transformer methods."""
@@ -18,6 +22,10 @@ class ResponseTransformer(Protocol[TransformedResponse_co]):
     def __call__(self, data: list[dict[str, Any]]) -> TransformedResponse_co:
         """Transforms a list of JSON-derived dictionaries to the target type."""
         ...
+
+def default_column_mapper(label: str) -> str:
+    """Applies default column mapper to GeoDataFrame or DataFrame column labels."""
+    return HYDROTOOLS_DATAFRAME_COLUMN_MAPPING.get(label, label)
 
 def raise_on_no_data(data: list[dict[str, Any]]) -> None:
     """Raises if data list is empty or all items are None.
@@ -56,11 +64,16 @@ def check_features(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
     raise_on_no_data(data)
     return data
 
-def to_geodataframe(data: list[dict[str, Any]]) -> gpd.GeoDataFrame:
+def to_geodataframe(
+        data: list[dict[str, Any]],
+        column_mapper: Optional[Renamer] = default_column_mapper
+) -> gpd.GeoDataFrame:
     """Transforms a list of GeoJSON-derived dictionaries to a single GeoDataFrame.
     
     Args:
         data: A list of deserialized GeoJSON responses from an OGC-compliant API.
+        column_mapper: Dict-like or function transformations to apply to that
+            column values. Passed directly to GeoDataFrame.rename with axis=1.
     
     Returns:
         Transformed and concatenated responses in a single GeoDataFrame.
@@ -72,15 +85,25 @@ def to_geodataframe(data: list[dict[str, Any]]) -> gpd.GeoDataFrame:
     raise_on_no_data(data)
 
     # Transform data
-    return gpd.GeoDataFrame(pd.concat([
+    dataframe = gpd.GeoDataFrame(pd.concat([
         gpd.GeoDataFrame.from_features(d) for d in data if d is not None
         ], ignore_index=True))
 
-def to_dataframe(data: list[dict[str, Any]]) -> pd.DataFrame:
+    # Apply optional mapping
+    if column_mapper is None:
+        return dataframe
+    return dataframe.rename(mapper=column_mapper, axis=1)
+
+def to_dataframe(
+        data: list[dict[str, Any]],
+        column_mapper: Optional[Renamer] = default_column_mapper
+) -> pd.DataFrame:
     """Transforms a list of GeoJSON-derived dictionaries to a single DataFrame.
     
     Args:
         data: A list of deserialized GeoJSON responses from an OGC-compliant API.
+        column_mapper: Dict-like or function transformations to apply to that
+            column values. Passed directly to DataFrame.rename with axis=1.
     
     Returns:
         Transformed and concatenated responses in a single DataFrame.
@@ -92,6 +115,11 @@ def to_dataframe(data: list[dict[str, Any]]) -> pd.DataFrame:
     raise_on_no_data(data)
 
     # Transform data
-    return pd.concat([
+    dataframe = pd.concat([
         pd.json_normalize(d, record_path=['features']) for d in data if d is not None
         ], ignore_index=True)
+
+    # Apply optional mapping
+    if column_mapper is None:
+        return dataframe
+    return dataframe.rename(mapper=column_mapper, axis=1)

--- a/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
@@ -83,10 +83,14 @@ def to_geodataframe(
     # Check for data
     raise_on_no_data(data)
 
+    # Flatten features
+    flat_features = []
+    for d in data:
+        if d and "features" in d:
+            flat_features.extend(d["features"])
+
     # Transform data
-    dataframe = gpd.GeoDataFrame(pd.concat([
-        gpd.GeoDataFrame.from_features(d) for d in data if d is not None
-        ], ignore_index=True))
+    dataframe = gpd.GeoDataFrame.from_features(flat_features)
 
     # Apply optional mapping
     if column_mapper is None:
@@ -113,10 +117,14 @@ def to_dataframe(
     # Check for data
     raise_on_no_data(data)
 
+    # Flatten features
+    flat_features = []
+    for d in data:
+        if d and "features" in d:
+            flat_features.extend(d["features"])
+
     # Transform data
-    dataframe = pd.concat([
-        pd.json_normalize(d, record_path=['features']) for d in data if d is not None
-        ], ignore_index=True)
+    dataframe = pd.json_normalize(flat_features)
 
     # Apply optional mapping
     if column_mapper is None:

--- a/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
@@ -76,3 +76,23 @@ def to_geodataframe(data: list[dict[str, Any]]) -> gpd.GeoDataFrame:
     return gpd.GeoDataFrame(pd.concat([
         gpd.GeoDataFrame.from_features(d) for d in data if d is not None
         ], ignore_index=True))
+
+def to_dataframe(data: list[dict[str, Any]]) -> pd.DataFrame:
+    """Transforms a list of GeoJSON-derived dictionaries to a single DataFrame.
+    
+    Args:
+        data: A list of deserialized GeoJSON responses from an OGC-compliant API.
+    
+    Returns:
+        Transformed and concatenated responses in a single DataFrame.
+    
+    Raises:
+        NoDataError if data is empty or all items are None.
+    """
+    # Check for data
+    raise_on_no_data(data)
+
+    # Transform data
+    return pd.concat([
+        pd.json_normalize(d, record_path=['features']) for d in data if d is not None
+        ], ignore_index=True)

--- a/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
@@ -1,0 +1,28 @@
+"""Defines transformation methods for handling deserialized JSON responses from
+USGS OGC APIs.
+"""
+from typing import Any, Protocol, TypeVar, runtime_checkable
+
+import pandas as pd
+import geopandas as gpd
+
+TransformedResponse_co = TypeVar("TransformedResponse_co", covariant=True)
+"""Generic transformed response type for transformer methods."""
+
+@runtime_checkable
+class ResponseTransformer(Protocol[TransformedResponse_co]):
+    """Protocol definition for response transformer methods."""
+    def __call__(self, data: list[dict[str, Any]]) -> TransformedResponse_co:
+        """Transforms a list of JSON-derived dictionaries to the target type."""
+        ...
+
+def to_geodataframe(data: list[dict[str, Any]]) -> gpd.GeoDataFrame:
+    """Transforms a list of GeoJSON-derived dictionaries to a single GeoDataFrame.
+    
+    Args:
+        data: A list of deserialized GeoJSON responses from an OGC-compliant API.
+    
+    Returns:
+        Transformed and concatenated responses in a single GeoDataFrame.
+    """
+    return gpd.GeoDataFrame(pd.concat([gpd.GeoDataFrame(d) for d in data], ignore_index=True))

--- a/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
@@ -6,8 +6,12 @@ from typing import Any, Protocol, TypeVar, runtime_checkable
 import pandas as pd
 import geopandas as gpd
 
-TransformedResponse_co = TypeVar("TransformedResponse_co", covariant=True)
+TransformedResponse_co = TypeVar("TransformedResponse_co",
+    default=list[dict[str, Any]], covariant=True)
 """Generic transformed response type for transformer methods."""
+
+class NoDataError(Exception):
+    """Custom exception raised when all data retrieval fails."""
 
 @runtime_checkable
 class ResponseTransformer(Protocol[TransformedResponse_co]):
@@ -15,6 +19,43 @@ class ResponseTransformer(Protocol[TransformedResponse_co]):
     def __call__(self, data: list[dict[str, Any]]) -> TransformedResponse_co:
         """Transforms a list of JSON-derived dictionaries to the target type."""
         ...
+
+def raise_on_no_data(data: list[dict[str, Any]]) -> None:
+    """Raises if data list is empty or all items are None.
+    
+    Args:
+        data: A list of deserialized GeoJSON responses from an OGC-compliant API.
+    
+    Raises:
+        NoDataError if data is empty or all items are None.
+    """
+    # Check for empty list
+    if not data:
+        raise NoDataError("No data available to parse.")
+
+    # Check for all None
+    if all(d is None for d in data):
+        raise NoDataError("All data returned were None.")
+
+    # Check for no features
+    if sum([d.get("numberReturned", 0) for d in data]) == 0:
+        raise NoDataError("All responses returned 0 features.")
+
+def check_features(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Checks a list of GeoJSON-derived dictionaries for minimal data.
+    
+    Args:
+        data: A list of deserialized GeoJSON responses from an OGC-compliant API.
+    
+    Returns:
+        Original responses in a single GeoDataFrame.
+    
+    Raises:
+        NoDataError if data is empty or all items are None.
+    """
+    # Check for data
+    raise_on_no_data(data)
+    return data
 
 def to_geodataframe(data: list[dict[str, Any]]) -> gpd.GeoDataFrame:
     """Transforms a list of GeoJSON-derived dictionaries to a single GeoDataFrame.
@@ -24,5 +65,14 @@ def to_geodataframe(data: list[dict[str, Any]]) -> gpd.GeoDataFrame:
     
     Returns:
         Transformed and concatenated responses in a single GeoDataFrame.
+    
+    Raises:
+        NoDataError if data is empty or all items are None.
     """
-    return gpd.GeoDataFrame(pd.concat([gpd.GeoDataFrame(d) for d in data], ignore_index=True))
+    # Check for data
+    raise_on_no_data(data)
+
+    # Transform data
+    return gpd.GeoDataFrame(pd.concat([
+        gpd.GeoDataFrame.from_features(d) for d in data if d is not None
+        ], ignore_index=True))

--- a/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
@@ -54,7 +54,7 @@ def check_features(data: list[dict[str, Any]]) -> list[dict[str, Any]]:
         data: A list of deserialized GeoJSON responses from an OGC-compliant API.
     
     Returns:
-        Original responses in a single GeoDataFrame.
+        Original list of responses.
     
     Raises:
         NoDataError if data is empty or all items are None.

--- a/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
@@ -2,7 +2,6 @@
 USGS OGC APIs.
 """
 from typing import Any, Protocol, TypeVar, runtime_checkable, Optional
-from enum import StrEnum
 
 import pandas as pd
 from pandas._typing import Renamer

--- a/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
@@ -9,16 +9,16 @@ import geopandas as gpd
 
 from .constants import HYDROTOOLS_DATAFRAME_COLUMN_MAPPING
 
-TransformedResponse_co = TypeVar("TransformedResponse_co", covariant=True)
+TransformedResponseT_co = TypeVar("TransformedResponseT_co", covariant=True)
 """Generic transformed response type for transformer methods."""
 
 class NoDataError(Exception):
     """Custom exception raised when all data retrieval fails."""
 
 @runtime_checkable
-class ResponseTransformer(Protocol[TransformedResponse_co]):
+class ResponseTransformer(Protocol[TransformedResponseT_co]):
     """Protocol definition for response transformer methods."""
-    def __call__(self, data: list[dict[str, Any]]) -> TransformedResponse_co:
+    def __call__(self, data: list[dict[str, Any]]) -> TransformedResponseT_co:
         """Transforms a list of JSON-derived dictionaries to the target type."""
         ...
 

--- a/python/waterdata_client/templates/clients.py.j2
+++ b/python/waterdata_client/templates/clients.py.j2
@@ -14,7 +14,7 @@ from typing import Sequence, Literal, Optional
 from yarl import URL
 from .base_client import BaseClient
 from .constants import USGSCollection
-from .transformers import TransformedResponse_co
+from .transformers import TransformedResponseT_co
 
 __all__ = [
 {% for item in collections %}
@@ -23,7 +23,7 @@ __all__ = [
 ]
 
 {% for item in collections %}
-class {{ item.class_name }}(BaseClient[TransformedResponse_co]):
+class {{ item.class_name }}(BaseClient[TransformedResponseT_co]):
     """
     {{ item.description | wordwrap(70) | indent(4) }}
     """
@@ -34,7 +34,7 @@ class {{ item.class_name }}(BaseClient[TransformedResponse_co]):
         {% for p in item.parameters %}
         {{ p.python_name }}: {{ p.type_hint }} = {{ p.default }},
         {% endfor %}
-        ) -> TransformedResponse_co:
+        ) -> TransformedResponseT_co:
         """Retrieve items from {{ item.value }}.
 
         Args:

--- a/python/waterdata_client/templates/clients.py.j2
+++ b/python/waterdata_client/templates/clients.py.j2
@@ -56,6 +56,6 @@ class {{ item.class_name }}(BaseClient[TransformedResponse_co]):
         data = self._get_json_responses(queries=[valid_query])
 
         # Transform
-        return self._handle_responses(data)
+        return self._handle_response(data)
 
 {% endfor %}

--- a/python/waterdata_client/templates/clients.py.j2
+++ b/python/waterdata_client/templates/clients.py.j2
@@ -14,6 +14,7 @@ from typing import Any, Sequence, Literal, Optional
 from yarl import URL
 from .base_client import BaseClient
 from .constants import USGSCollection
+from .transformers import TransformedResponse_co
 
 __all__ = [
 {% for item in collections %}
@@ -22,7 +23,7 @@ __all__ = [
 ]
 
 {% for item in collections %}
-class {{ item.class_name }}(BaseClient):
+class {{ item.class_name }}(BaseClient[TransformedResponse_co]):
     """
     {{ item.description | wordwrap(70) | indent(4) }}
     """
@@ -33,7 +34,7 @@ class {{ item.class_name }}(BaseClient):
         {% for p in item.parameters %}
         {{ p.python_name }}: {{ p.type_hint }} = {{ p.default }},
         {% endfor %}
-        ) -> list[dict[str, Any]]:
+        ) -> TransformedResponse_co | list[dict[str, Any]]:
         """Retrieve items from {{ item.value }}.
 
         Args:
@@ -52,6 +53,9 @@ class {{ item.class_name }}(BaseClient):
         valid_query = {k: v for k, v in query.items() if v is not None}
 
         # Get responses
-        return self._get_json_responses(queries=[valid_query])
+        data = self._get_json_responses(queries=[valid_query])
+
+        # Transform
+        return self._handle_responses(data)
 
 {% endfor %}

--- a/python/waterdata_client/templates/clients.py.j2
+++ b/python/waterdata_client/templates/clients.py.j2
@@ -10,7 +10,7 @@ JSON Schema source: {{ schema_source }}
 JSON Schema version: {{ schema_version }}
 OpenAPI version: {{ openapi_version }}
 """
-from typing import Any, Sequence, Literal, Optional
+from typing import Sequence, Literal, Optional
 from yarl import URL
 from .base_client import BaseClient
 from .constants import USGSCollection

--- a/python/waterdata_client/templates/clients.py.j2
+++ b/python/waterdata_client/templates/clients.py.j2
@@ -34,7 +34,7 @@ class {{ item.class_name }}(BaseClient[TransformedResponse_co]):
         {% for p in item.parameters %}
         {{ p.python_name }}: {{ p.type_hint }} = {{ p.default }},
         {% endfor %}
-        ) -> TransformedResponse_co | list[dict[str, Any]]:
+        ) -> TransformedResponse_co:
         """Retrieve items from {{ item.value }}.
 
         Args:

--- a/python/waterdata_client/templates/constants.py.j2
+++ b/python/waterdata_client/templates/constants.py.j2
@@ -31,3 +31,33 @@ class USGSCollection(StrEnum):
     {% for item in collections %}
     {{ item.enum_member }} = "{{ item.value }}"
     {% endfor %}
+
+class HydroToolsColumn(StrEnum):
+    """Canonical HydroTools column labels."""
+    VALUE = "value"
+    VALUE_TIME = "value_time"
+    VARIABLE_NAME = "variable_name"
+    MEASUREMENT_UNIT = "measurement_unit"
+    QUALIFIERS = "qualifiers"
+    SERIES = "series"
+    CONFIGURATION = "configuration"
+    REFERENCE_TIME = "reference_time"
+    LONGITUDE = "longitude"
+    LATITUDE = "latitude"
+    CRS = "crs"
+    GEOMETRY = "geometry"
+    USGS_SITE_CODE = "usgs_site_code"
+    NWM_FEATURE_ID = "nwm_feature_id"
+    NWS_LID = "nws_lid"
+    USACE_GAUGE_ID = "usace_gauge_id"
+    START = "start"
+    END = "end"
+
+CATEGORICAL_COLUMNS: list[HydroToolsColumn] = [
+    HydroToolsColumn.VARIABLE_NAME,
+    HydroToolsColumn.USGS_SITE_CODE,
+    HydroToolsColumn.MEASUREMENT_UNIT,
+    HydroToolsColumn.QUALIFIERS
+]
+"""List of columns to transform to categorical types."""
+

--- a/python/waterdata_client/templates/constants.py.j2
+++ b/python/waterdata_client/templates/constants.py.j2
@@ -60,14 +60,6 @@ class HydroToolsColumn(StrEnum):
     LAST_MODIFIED = "last_modified"
     GEO_FEATURE_ID = "geo_feature_id"
 
-CATEGORICAL_COLUMNS: list[HydroToolsColumn] = [
-    HydroToolsColumn.VARIABLE_NAME,
-    HydroToolsColumn.USGS_SITE_CODE,
-    HydroToolsColumn.MEASUREMENT_UNIT,
-    HydroToolsColumn.QUALIFIERS
-]
-"""List of columns to transform to categorical types."""
-
 HYDROTOOLS_DATAFRAME_COLUMN_MAPPING: dict[str, HydroToolsColumn] = {
     "properties.id": HydroToolsColumn.GEO_FEATURE_ID,
     "properties.time_series_id": HydroToolsColumn.TIME_SERIES_ID,

--- a/python/waterdata_client/templates/constants.py.j2
+++ b/python/waterdata_client/templates/constants.py.j2
@@ -79,7 +79,18 @@ HYDROTOOLS_DATAFRAME_COLUMN_MAPPING: dict[str, HydroToolsColumn] = {
     "properties.unit_of_measure": HydroToolsColumn.MEASUREMENT_UNIT,
     "properties.approval_status": HydroToolsColumn.APPROVAL_STATUS,
     "properties.qualifier": HydroToolsColumn.QUALIFIERS,
-    "properties.last_modified": HydroToolsColumn.LAST_MODIFIED
+    "properties.last_modified": HydroToolsColumn.LAST_MODIFIED,
+    "id": HydroToolsColumn.ID,
+    "time_series_id": HydroToolsColumn.TIME_SERIES_ID,
+    "monitoring_location_id": HydroToolsColumn.USGS_SITE_CODE,
+    "parameter_code": HydroToolsColumn.PARAMETER_CODE,
+    "statistic_id": HydroToolsColumn.STATISTIC_ID,
+    "time": HydroToolsColumn.VALUE_TIME,
+    "value": HydroToolsColumn.VALUE,
+    "unit_of_measure": HydroToolsColumn.MEASUREMENT_UNIT,
+    "approval_status": HydroToolsColumn.APPROVAL_STATUS,
+    "qualifier": HydroToolsColumn.QUALIFIERS,
+    "last_modified": HydroToolsColumn.LAST_MODIFIED
 }
 """Mapping from default pandas.json_normalize column names to HydroTools
 canonical column labels."""

--- a/python/waterdata_client/templates/constants.py.j2
+++ b/python/waterdata_client/templates/constants.py.j2
@@ -52,6 +52,13 @@ class HydroToolsColumn(StrEnum):
     USACE_GAUGE_ID = "usace_gauge_id"
     START = "start"
     END = "end"
+    ID = "id"
+    TIME_SERIES_ID = "time_series_id"
+    PARAMETER_CODE = "parameter_code"
+    STATISTIC_ID = "statistic_id"
+    APPROVAL_STATUS = "approval_status"
+    LAST_MODIFIED = "last_modified"
+    GEO_FEATURE_ID = "geo_feature_id"
 
 CATEGORICAL_COLUMNS: list[HydroToolsColumn] = [
     HydroToolsColumn.VARIABLE_NAME,
@@ -60,4 +67,20 @@ CATEGORICAL_COLUMNS: list[HydroToolsColumn] = [
     HydroToolsColumn.QUALIFIERS
 ]
 """List of columns to transform to categorical types."""
+
+HYDROTOOLS_DATAFRAME_COLUMN_MAPPING: dict[str, HydroToolsColumn] = {
+    "properties.id": HydroToolsColumn.GEO_FEATURE_ID,
+    "properties.time_series_id": HydroToolsColumn.TIME_SERIES_ID,
+    "properties.monitoring_location_id": HydroToolsColumn.USGS_SITE_CODE,
+    "properties.parameter_code": HydroToolsColumn.PARAMETER_CODE,
+    "properties.statistic_id": HydroToolsColumn.STATISTIC_ID,
+    "properties.time": HydroToolsColumn.VALUE_TIME,
+    "properties.value": HydroToolsColumn.VALUE,
+    "properties.unit_of_measure": HydroToolsColumn.MEASUREMENT_UNIT,
+    "properties.approval_status": HydroToolsColumn.APPROVAL_STATUS,
+    "properties.qualifier": HydroToolsColumn.QUALIFIERS,
+    "properties.last_modified": HydroToolsColumn.LAST_MODIFIED
+}
+"""Mapping from default pandas.json_normalize column names to HydroTools
+canonical column labels."""
 

--- a/python/waterdata_client/tests/test_clients.py
+++ b/python/waterdata_client/tests/test_clients.py
@@ -39,7 +39,7 @@ from hydrotools.waterdata_client import (
 ])
 def test_generated_client_get_mapping(client_class, test_args, expected_query_subset):
     """Verify that generated get methods correctly pack arguments into API query keys."""
-    client = client_class()
+    client = client_class(transformer=None)
 
     # We patch the internal pipeline to inspect the queries before network I/O
     with patch.object(client_class, "_get_json_responses") as mock_pipeline:
@@ -58,7 +58,7 @@ def test_generated_client_get_mapping(client_class, test_args, expected_query_su
 
 def test_generated_client_filters_none():
     """Verify that None arguments are excluded from the final query dictionary."""
-    client = DailyClient()
+    client = DailyClient(transformer=None)
 
     with patch.object(DailyClient, "_get_json_responses") as mock_pipeline:
         # Call with some Nones and some values
@@ -86,7 +86,7 @@ def test_generated_client_uses_correct_endpoint():
 
 def test_get_all_is_called_with_client_config():
     """Verify that the high-level get method passes client settings to the network layer."""
-    client = ContinuousClient(concurrency_limit=99, max_retries=5)
+    client = ContinuousClient(concurrency_limit=99, max_retries=5, transformer=None)
 
     # Patch the lower-level get_all called by _get_json_responses
     with patch("hydrotools.waterdata_client.base_client.get_all") as mock_get_all:

--- a/python/waterdata_client/tests/test_transformers.py
+++ b/python/waterdata_client/tests/test_transformers.py
@@ -63,7 +63,7 @@ def test_raise_on_no_data_zero_features(empty_geojson_response):
 
 def test_to_dataframe_success(mock_geojson_response):
     """Verify JSON to DataFrame flattening."""
-    df = to_dataframe(mock_geojson_response)
+    df = to_dataframe(mock_geojson_response, column_mapper=None)
 
     assert isinstance(df, pd.DataFrame)
     assert len(df) == 2
@@ -86,6 +86,6 @@ def test_transformer_integration_logic(mock_geojson_response):
     # Simulate two pages/batches of data
     multi_batch = mock_geojson_response + mock_geojson_response
 
-    df = to_dataframe(multi_batch)
+    df = to_dataframe(multi_batch, column_mapper=None)
     assert len(df) == 4
     assert df.iloc[0]["properties.id"] == df.iloc[2]["properties.id"]

--- a/python/waterdata_client/tests/test_transformers.py
+++ b/python/waterdata_client/tests/test_transformers.py
@@ -73,7 +73,7 @@ def test_to_dataframe_success(mock_geojson_response):
 
 def test_to_geodataframe_success(mock_geojson_response):
     """Verify JSON to GeoDataFrame conversion."""
-    gdf = to_geodataframe(mock_geojson_response)
+    gdf = to_geodataframe(mock_geojson_response, column_mapper=None)
 
     assert isinstance(gdf, gpd.GeoDataFrame)
     assert len(gdf) == 2

--- a/python/waterdata_client/tests/test_transformers.py
+++ b/python/waterdata_client/tests/test_transformers.py
@@ -1,0 +1,91 @@
+"""Tests for the transformers module."""
+import pytest
+import pandas as pd
+import geopandas as gpd
+from hydrotools.waterdata_client.transformers import (
+    to_dataframe,
+    to_geodataframe,
+    raise_on_no_data,
+    NoDataError
+)
+
+@pytest.fixture
+def mock_geojson_response():
+    """Mock OGC FeatureCollection response."""
+    return [{
+        'type': 'FeatureCollection',
+        'numberReturned': 2,
+        'features': [
+            {
+                'type': 'Feature',
+                'properties': {
+                    'id': '1',
+                    'monitoring_location_id': 'USGS-01',
+                    'value': '1.1'
+                },
+                'geometry': {'type': 'Point', 'coordinates': [0, 0]}
+            },
+            {
+                'type': 'Feature',
+                'properties': {
+                    'id': '2',
+                    'monitoring_location_id': 'USGS-01',
+                    'value': '2.2'
+                },
+                'geometry': {'type': 'Point', 'coordinates': [1, 1]}
+            }
+        ]
+    }]
+
+@pytest.fixture
+def empty_geojson_response():
+    """Mock response with zero features."""
+    return [{
+        'type': 'FeatureCollection',
+        'numberReturned': 0,
+        'features': []
+    }]
+
+def test_raise_on_no_data_empty():
+    """Verify NoDataError on empty input."""
+    with pytest.raises(NoDataError, match="No data available"):
+        raise_on_no_data([])
+
+def test_raise_on_no_data_none():
+    """Verify NoDataError when all items are None."""
+    with pytest.raises(NoDataError, match="All data returned were None"):
+        raise_on_no_data([None, None])
+
+def test_raise_on_no_data_zero_features(empty_geojson_response):
+    """Verify NoDataError when numberReturned is 0."""
+    with pytest.raises(NoDataError, match="returned 0 features"):
+        raise_on_no_data(empty_geojson_response)
+
+def test_to_dataframe_success(mock_geojson_response):
+    """Verify JSON to DataFrame flattening."""
+    df = to_dataframe(mock_geojson_response)
+
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 2
+    # Verify json_normalize dot notation
+    assert "properties.monitoring_location_id" in df.columns
+    assert df.loc[0, "properties.value"] == "1.1"
+
+def test_to_geodataframe_success(mock_geojson_response):
+    """Verify JSON to GeoDataFrame conversion."""
+    gdf = to_geodataframe(mock_geojson_response)
+
+    assert isinstance(gdf, gpd.GeoDataFrame)
+    assert len(gdf) == 2
+    assert "monitoring_location_id" in gdf.columns
+    assert hasattr(gdf, "geometry")
+    assert gdf.geometry.iloc[0].x == 0
+
+def test_transformer_integration_logic(mock_geojson_response):
+    """Verify that multiple collections are concatenated correctly."""
+    # Simulate two pages/batches of data
+    multi_batch = mock_geojson_response + mock_geojson_response
+
+    df = to_dataframe(multi_batch)
+    assert len(df) == 4
+    assert df.iloc[0]["properties.id"] == df.iloc[2]["properties.id"]


### PR DESCRIPTION
This PR introduces new functionality to transform deserialized GeoJSON into alternative formats. Prior to this PR, all classes defined in `clients.py` could only return `dict`. This PR adds the ability to further process these results into more useful formats for data scientists. This PR also adds column label mapping from WaterData labels to HydroTools canonical labels for some backwards compatibility with `hydrotools.nwis_client`.

## Changes

- `pyproject.toml` Added `geopandas` as a dependency.
- `base_client.py` Added new `transformer` attribute (a `Callable` type) and `_handle_response` method that calls the `transformer`.
- `clients.py` Regenerated from template.
- `constants.py` Regenerated from template.
- `transformers.py` New module that defines a `ResponseTransformer` protocol and `TransformedResponse_co` TypeVar. Also includes three example transformer methods: `check_features`, `to_geodataframe`, and `to_dataframe`.
- `clients.py.j2` Updates Jinja2 template for `clients.py` to include application of optional tranformer.
- `constants.py.j2` Updates Jinja2 template with column enums and mapping from waterdata labels to hydrotools canonical columns.
- `README.md` Added example using new `to_geodataframe` transformer.

## Testing

 - `test_clients.py` Updated to account for new transformer kwarg. Set to None to maintain current tests.
 - `test_transformers.py` Add testing for transformers.

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [ ] Placeholder code is flagged / future todos are captured in comments
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
