### PR TITLE
WaterData Client DataFrame Memory Optimizations

### DIFF
--- a/python/waterdata_client/src/hydrotools/waterdata_client/constants.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/constants.py
@@ -5,7 +5,7 @@ by inspecting the USGS OGC API JSON schema and identifying all "items" endpoints
 
 Package version: 0.8.0a0
 Generation script: build_constants.py
-Generated: 2026-05-01 15:29:03 Z
+Generated: 2026-05-05 17:55:55 Z
 JSON Schema source: https://api.waterdata.usgs.gov/ogcapi/v0/openapi?f=json
 JSON Schema version: 0.49.2
 OpenAPI version: 3.0.2
@@ -90,6 +90,9 @@ class HydroToolsColumn(StrEnum):
     APPROVAL_STATUS = "approval_status"
     LAST_MODIFIED = "last_modified"
     GEO_FEATURE_ID = "geo_feature_id"
+    GEOMETRY_TYPE = "geometry_type"
+    COORDINATES = "coordinates"
+    TYPE = "type"
 
 HYDROTOOLS_DATAFRAME_COLUMN_MAPPING: dict[str, HydroToolsColumn] = {
     "properties.id": HydroToolsColumn.GEO_FEATURE_ID,
@@ -113,7 +116,10 @@ HYDROTOOLS_DATAFRAME_COLUMN_MAPPING: dict[str, HydroToolsColumn] = {
     "unit_of_measure": HydroToolsColumn.MEASUREMENT_UNIT,
     "approval_status": HydroToolsColumn.APPROVAL_STATUS,
     "qualifier": HydroToolsColumn.QUALIFIERS,
-    "last_modified": HydroToolsColumn.LAST_MODIFIED
+    "last_modified": HydroToolsColumn.LAST_MODIFIED,
+    "geometry.type": HydroToolsColumn.GEOMETRY_TYPE,
+    "geometry.coordinates": HydroToolsColumn.COORDINATES,
+    "type": HydroToolsColumn.TYPE
 }
 """Mapping from default pandas.json_normalize column names to HydroTools
 canonical column labels."""

--- a/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
@@ -147,9 +147,9 @@ def optimize_series_categorical(s: pd.Series) -> pd.Series:
 
 def optimize_series_datetime_utc(s: pd.Series) -> pd.Series:
     """Applies pandas.to_datetime to a pandas.Series. Converts to UTC and strips
-    timezone awareness.
+    timezone awareness. Defaults to unit 's' (seconds).
     """
-    return pd.to_datetime(s, utc=True).dt.tz_localize(None)
+    return pd.to_datetime(s, utc=True).dt.tz_localize(None).astype("datetime64[s]")
 
 def optimize_series_float32(s: pd.Series) -> pd.Series:
     """Applies float32 type to a pandas.Series."""

--- a/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
@@ -137,75 +137,75 @@ def to_dataframe(
 DataFrameT = TypeVar("DataFrameT", bound=pd.DataFrame)
 """pandas.DataFrame or geopandas.GeoDataFrame"""
 
-SeriesOptimizer = Callable[[pd.Series], pd.Series]
-"""A callable that takes a pandas.Series and returns a memory-optimized version
+SeriesTransformer = Callable[[pd.Series], pd.Series]
+"""A callable that takes a pandas.Series and returns a transformed version
 of the same."""
 
-def optimize_series_categorical(s: pd.Series) -> pd.Series:
+def categorize_series(s: pd.Series) -> pd.Series:
     """Applies pandas.Categorical type to a pandas.Series."""
     return s.astype("category")
 
-def optimize_series_datetime_utc(s: pd.Series) -> pd.Series:
+def downscale_datetime_series(s: pd.Series) -> pd.Series:
     """Applies pandas.to_datetime to a pandas.Series. Converts to UTC and strips
     timezone awareness. Defaults to unit 's' (seconds).
     """
     return pd.to_datetime(s, utc=True).dt.tz_localize(None).astype("datetime64[s]")
 
-def optimize_series_float32(s: pd.Series) -> pd.Series:
+def downscale_float32_series(s: pd.Series) -> pd.Series:
     """Applies float32 type to a pandas.Series."""
     return pd.to_numeric(s).astype("float32")
 
-SERIES_OPTIMIZERS: dict[HydroToolsColumn, SeriesOptimizer] = {
+SERIES_TRANSFORMERS: dict[HydroToolsColumn, SeriesTransformer] = {
     # Categorical optimizations
-    HydroToolsColumn.USGS_SITE_CODE: optimize_series_categorical,
-    HydroToolsColumn.USACE_GAUGE_ID: optimize_series_categorical,
-    HydroToolsColumn.NWS_LID: optimize_series_categorical,
-    HydroToolsColumn.PARAMETER_CODE: optimize_series_categorical,
-    HydroToolsColumn.STATISTIC_ID: optimize_series_categorical,
-    HydroToolsColumn.MEASUREMENT_UNIT: optimize_series_categorical,
-    HydroToolsColumn.VARIABLE_NAME: optimize_series_categorical,
-    HydroToolsColumn.QUALIFIERS: optimize_series_categorical,
-    HydroToolsColumn.CONFIGURATION: optimize_series_categorical,
-    HydroToolsColumn.APPROVAL_STATUS: optimize_series_categorical,
-    HydroToolsColumn.ID: optimize_series_categorical,
-    HydroToolsColumn.TIME_SERIES_ID: optimize_series_categorical,
-    HydroToolsColumn.GEOMETRY_TYPE: optimize_series_categorical,
-    HydroToolsColumn.GEO_FEATURE_ID: optimize_series_categorical,
-    HydroToolsColumn.TYPE: optimize_series_categorical,
+    HydroToolsColumn.USGS_SITE_CODE: categorize_series,
+    HydroToolsColumn.USACE_GAUGE_ID: categorize_series,
+    HydroToolsColumn.NWS_LID: categorize_series,
+    HydroToolsColumn.PARAMETER_CODE: categorize_series,
+    HydroToolsColumn.STATISTIC_ID: categorize_series,
+    HydroToolsColumn.MEASUREMENT_UNIT: categorize_series,
+    HydroToolsColumn.VARIABLE_NAME: categorize_series,
+    HydroToolsColumn.QUALIFIERS: categorize_series,
+    HydroToolsColumn.CONFIGURATION: categorize_series,
+    HydroToolsColumn.APPROVAL_STATUS: categorize_series,
+    HydroToolsColumn.ID: categorize_series,
+    HydroToolsColumn.TIME_SERIES_ID: categorize_series,
+    HydroToolsColumn.GEOMETRY_TYPE: categorize_series,
+    HydroToolsColumn.GEO_FEATURE_ID: categorize_series,
+    HydroToolsColumn.TYPE: categorize_series,
 
     # Numeric optimizations
-    HydroToolsColumn.VALUE: optimize_series_float32,
+    HydroToolsColumn.VALUE: downscale_float32_series,
 
     # DateTime optimizations
-    HydroToolsColumn.VALUE_TIME: optimize_series_datetime_utc,
-    HydroToolsColumn.LAST_MODIFIED: optimize_series_datetime_utc,
-    HydroToolsColumn.START: optimize_series_datetime_utc,
-    HydroToolsColumn.END: optimize_series_datetime_utc
+    HydroToolsColumn.VALUE_TIME: downscale_datetime_series,
+    HydroToolsColumn.LAST_MODIFIED: downscale_datetime_series,
+    HydroToolsColumn.START: downscale_datetime_series,
+    HydroToolsColumn.END: downscale_datetime_series
 }
 """Mapping from canonical hydrotools columns to optimization function."""
 
 def optimize_dataframe(
         dataframe: DataFrameT,
-        optimizations: Optional[dict[HydroToolsColumn, SeriesOptimizer]] = None
+        transformations: Optional[dict[HydroToolsColumn, SeriesTransformer]] = None
 ) -> DataFrameT:
-    """Apply column-specific optimizations to a dataframe.
+    """Apply column-specific transformations to a dataframe to reduce memory-usage.
     
     Args:
         dataframe: Dataframe to be optimized.
-        optimizations: Mapping from column labels to optimization functions.
-            Defaults to hydrotools canonical optimizations.
+        transformations: Mapping from column labels to optimization functions.
+            Defaults to hydrotools canonical transformations.
     
     Returns:
         Optimized dataframe.
     """
-    if optimizations is None:
-        optimizations = SERIES_OPTIMIZERS
+    if transformations is None:
+        transformations = SERIES_TRANSFORMERS
 
     # Copy to avoid set with copy error. Cast back to original dataframe type.
     df = cast(DataFrameT, dataframe.copy())
 
     # Look for optimizable columns
-    for column, optimizer in optimizations.items():
+    for column, optimizer in transformations.items():
         if column.value in df.columns:
             # Apply the conversion
             df[column.value] = optimizer(df[column.value])

--- a/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
@@ -1,13 +1,14 @@
 """Defines transformation methods for handling deserialized JSON responses from
 USGS OGC APIs.
 """
-from typing import Any, Protocol, TypeVar, runtime_checkable, Optional
+from typing import (Any, Protocol, TypeVar, runtime_checkable, Optional,
+    Callable, cast)
 
 import pandas as pd
 from pandas._typing import Renamer
 import geopandas as gpd
 
-from .constants import HYDROTOOLS_DATAFRAME_COLUMN_MAPPING
+from .constants import HYDROTOOLS_DATAFRAME_COLUMN_MAPPING, HydroToolsColumn
 
 TransformedResponseT_co = TypeVar("TransformedResponseT_co", covariant=True)
 """Generic transformed response type for transformer methods."""
@@ -130,3 +131,129 @@ def to_dataframe(
     if column_mapper is None:
         return dataframe
     return dataframe.rename(mapper=column_mapper, axis=1)
+
+# pickle/multiprocessing friendly optimization strategies
+
+DataFrameT = TypeVar("DataFrameT", bound=pd.DataFrame)
+"""pandas.DataFrame or geopandas.GeoDataFrame"""
+
+SeriesOptimizer = Callable[[pd.Series], pd.Series]
+"""A callable that takes a pandas.Series and returns a memory-optimized version
+of the same."""
+
+def optimize_series_categorical(s: pd.Series) -> pd.Series:
+    """Applies pandas.Categorical type to a pandas.Series."""
+    return s.astype("category")
+
+def optimize_series_datetime_utc(s: pd.Series) -> pd.Series:
+    """Applies pandas.to_datetime to a pandas.Series. Converts to UTC and strips
+    timezone awareness.
+    """
+    return pd.to_datetime(s, utc=True).dt.tz_localize(None)
+
+def optimize_series_float32(s: pd.Series) -> pd.Series:
+    """Applies float32 type to a pandas.Series."""
+    return pd.to_numeric(s).astype("float32")
+
+SERIES_OPTIMIZERS: dict[HydroToolsColumn, SeriesOptimizer] = {
+    # Categorical optimizations
+    HydroToolsColumn.USGS_SITE_CODE: optimize_series_categorical,
+    HydroToolsColumn.USACE_GAUGE_ID: optimize_series_categorical,
+    HydroToolsColumn.NWS_LID: optimize_series_categorical,
+    HydroToolsColumn.PARAMETER_CODE: optimize_series_categorical,
+    HydroToolsColumn.STATISTIC_ID: optimize_series_categorical,
+    HydroToolsColumn.MEASUREMENT_UNIT: optimize_series_categorical,
+    HydroToolsColumn.VARIABLE_NAME: optimize_series_categorical,
+    HydroToolsColumn.QUALIFIERS: optimize_series_categorical,
+    HydroToolsColumn.CONFIGURATION: optimize_series_categorical,
+    HydroToolsColumn.APPROVAL_STATUS: optimize_series_categorical,
+    HydroToolsColumn.ID: optimize_series_categorical,
+    HydroToolsColumn.TIME_SERIES_ID: optimize_series_categorical,
+    HydroToolsColumn.GEOMETRY_TYPE: optimize_series_categorical,
+    HydroToolsColumn.GEO_FEATURE_ID: optimize_series_categorical,
+    HydroToolsColumn.TYPE: optimize_series_categorical,
+
+    # Numeric optimizations
+    HydroToolsColumn.VALUE: optimize_series_float32,
+
+    # DateTime optimizations
+    HydroToolsColumn.VALUE_TIME: optimize_series_datetime_utc,
+    HydroToolsColumn.LAST_MODIFIED: optimize_series_datetime_utc,
+    HydroToolsColumn.START: optimize_series_datetime_utc,
+    HydroToolsColumn.END: optimize_series_datetime_utc
+}
+"""Mapping from canonical hydrotools columns to optimization function."""
+
+def optimize_dataframe(
+        dataframe: DataFrameT,
+        optimizations: Optional[dict[HydroToolsColumn, SeriesOptimizer]] = None
+) -> DataFrameT:
+    """Apply column-specific optimizations to a dataframe.
+    
+    Args:
+        dataframe: Dataframe to be optimized.
+        optimizations: Mapping from column labels to optimization functions.
+            Defaults to hydrotools canonical optimizations.
+    
+    Returns:
+        Optimized dataframe.
+    """
+    if optimizations is None:
+        optimizations = SERIES_OPTIMIZERS
+
+    # Copy to avoid set with copy error. Cast back to original dataframe type.
+    df = cast(DataFrameT, dataframe.copy())
+
+    # Look for optimizable columns
+    for column, optimizer in optimizations.items():
+        if column.value in df.columns:
+            # Apply the conversion
+            df[column.value] = optimizer(df[column.value])
+
+    return df
+
+def to_optimized_geodataframe(
+        data: list[dict[str, Any]],
+        column_mapper: Optional[Renamer] = default_column_mapper
+) -> gpd.GeoDataFrame:
+    """Transforms a list of GeoJSON-derived dictionaries to a single GeoDataFrame
+    with memory-optimizations.
+    
+    Args:
+        data: A list of deserialized GeoJSON responses from an OGC-compliant API.
+        column_mapper: Dict-like or function transformations to apply to that
+            column values. Passed directly to GeoDataFrame.rename with axis=1.
+    
+    Returns:
+        Transformed and concatenated responses in a single GeoDataFrame.
+    
+    Raises:
+        NoDataError if data is empty or all items are None.
+    """
+    # Apply base transformation and optimize
+    return optimize_dataframe(to_geodataframe(
+        data=data, column_mapper=column_mapper
+    ))
+
+def to_optimized_dataframe(
+        data: list[dict[str, Any]],
+        column_mapper: Optional[Renamer] = default_column_mapper
+) -> pd.DataFrame:
+    """Transforms a list of GeoJSON-derived dictionaries to a single DataFrame
+    with memory-optimizations.
+    
+    Args:
+        data: A list of deserialized GeoJSON responses from an OGC-compliant API.
+        column_mapper: Dict-like or function transformations to apply to that
+            column values. Passed directly to DataFrame.rename with axis=1.
+    
+    Returns:
+        Transformed and concatenated responses in a single DataFrame.
+    
+    Raises:
+        NoDataError if data is empty or all items are None.
+    """
+    # Apply base transformation and optimize
+    return optimize_dataframe(to_dataframe(
+        data=data, column_mapper=column_mapper
+    ))

--- a/python/waterdata_client/templates/constants.py.j2
+++ b/python/waterdata_client/templates/constants.py.j2
@@ -59,6 +59,9 @@ class HydroToolsColumn(StrEnum):
     APPROVAL_STATUS = "approval_status"
     LAST_MODIFIED = "last_modified"
     GEO_FEATURE_ID = "geo_feature_id"
+    GEOMETRY_TYPE = "geometry_type"
+    COORDINATES = "coordinates"
+    TYPE = "type"
 
 HYDROTOOLS_DATAFRAME_COLUMN_MAPPING: dict[str, HydroToolsColumn] = {
     "properties.id": HydroToolsColumn.GEO_FEATURE_ID,
@@ -82,7 +85,10 @@ HYDROTOOLS_DATAFRAME_COLUMN_MAPPING: dict[str, HydroToolsColumn] = {
     "unit_of_measure": HydroToolsColumn.MEASUREMENT_UNIT,
     "approval_status": HydroToolsColumn.APPROVAL_STATUS,
     "qualifier": HydroToolsColumn.QUALIFIERS,
-    "last_modified": HydroToolsColumn.LAST_MODIFIED
+    "last_modified": HydroToolsColumn.LAST_MODIFIED,
+    "geometry.type": HydroToolsColumn.GEOMETRY_TYPE,
+    "geometry.coordinates": HydroToolsColumn.COORDINATES,
+    "type": HydroToolsColumn.TYPE
 }
 """Mapping from default pandas.json_normalize column names to HydroTools
 canonical column labels."""

--- a/python/waterdata_client/tests/test_transformers.py
+++ b/python/waterdata_client/tests/test_transformers.py
@@ -1,12 +1,17 @@
 """Tests for the transformers module."""
 import pytest
+import numpy as np
 import pandas as pd
 import geopandas as gpd
+from hydrotools.waterdata_client.constants import HydroToolsColumn
 from hydrotools.waterdata_client.transformers import (
     to_dataframe,
     to_geodataframe,
     raise_on_no_data,
-    NoDataError
+    NoDataError,
+    optimize_dataframe,
+    to_optimized_dataframe,
+    to_optimized_geodataframe
 )
 
 @pytest.fixture
@@ -21,7 +26,8 @@ def mock_geojson_response():
                 'properties': {
                     'id': '1',
                     'monitoring_location_id': 'USGS-01',
-                    'value': '1.1'
+                    'value': '1.1',
+                    'time': '2026-05-05T18:15:00+00:00'
                 },
                 'geometry': {'type': 'Point', 'coordinates': [0, 0]}
             },
@@ -30,7 +36,8 @@ def mock_geojson_response():
                 'properties': {
                     'id': '2',
                     'monitoring_location_id': 'USGS-01',
-                    'value': '2.2'
+                    'value': '2.2',
+                    'time': '2026-05-05T18:30:00+00:00'
                 },
                 'geometry': {'type': 'Point', 'coordinates': [1, 1]}
             }
@@ -89,3 +96,64 @@ def test_transformer_integration_logic(mock_geojson_response):
     df = to_dataframe(multi_batch, column_mapper=None)
     assert len(df) == 4
     assert df.iloc[0]["properties.id"] == df.iloc[2]["properties.id"]
+
+##
+def test_optimize_dataframe_dtypes(mock_geojson_response):
+    """Verify that columns are correctly cast to optimized types."""
+    # Create a raw dataframe with strings and float64
+    df = pd.DataFrame({
+        HydroToolsColumn.VALUE: ["1.1", "2.2"],
+        HydroToolsColumn.USGS_SITE_CODE: ["USGS-01", "USGS-01"],
+        HydroToolsColumn.VALUE_TIME: ["2026-05-01T12:00:00Z", "2026-05-01T13:00:00Z"]
+    })
+
+    optimized_df = optimize_dataframe(df)
+
+    # Check numeric downcasting
+    assert optimized_df[HydroToolsColumn.VALUE].dtype == np.float32
+
+    # Check categorical casting
+    assert isinstance(optimized_df[HydroToolsColumn.USGS_SITE_CODE].dtype, pd.CategoricalDtype)
+
+    # Check datetime conversion and TZ stripping
+    assert pd.api.types.is_datetime64_any_dtype(optimized_df[HydroToolsColumn.VALUE_TIME])
+    assert optimized_df[HydroToolsColumn.VALUE_TIME].dt.tz is None
+
+def test_to_optimized_geodataframe_preserves_type(mock_geojson_response):
+    """Verify that optimized GeoDataFrames retain their spatial identity."""
+    gdf = to_optimized_geodataframe(mock_geojson_response)
+
+    assert isinstance(gdf, gpd.GeoDataFrame)
+    assert hasattr(gdf, "geometry")
+    # Verify optimization was applied
+    assert isinstance(gdf[HydroToolsColumn.USGS_SITE_CODE].dtype, pd.CategoricalDtype)
+
+def test_to_optimized_dataframe_integration(mock_geojson_response):
+    """Test full pipeline from JSON to optimized tabular format."""
+    df = to_optimized_dataframe(mock_geojson_response)
+
+    # Verify columns are correctly mapped and optimized
+    assert HydroToolsColumn.VALUE in df.columns
+    assert df[HydroToolsColumn.VALUE].dtype == np.float32
+    assert df[HydroToolsColumn.VALUE_TIME].dtype == "datetime64[s]"
+
+def test_optimize_dataframe_custom_strategies():
+    """Verify that custom optimization dictionaries can be injected."""
+    df = pd.DataFrame({
+        "test_col": [1, 2, 3],
+        "value": ["1.0", "2.0", "3.0"]
+        })
+
+    # Default should leave 'test_col' untouched
+    optimized_df = optimize_dataframe(df)
+    assert optimized_df["test_col"].dtype == np.int64
+    assert optimized_df["value"].dtype == np.float32
+
+    # Custom optimizer
+    optimized_df = optimize_dataframe(
+        df,
+        optimizations={
+            HydroToolsColumn.VALUE: pd.to_numeric
+        }
+        )
+    assert optimized_df["value"].dtype == np.float64

--- a/python/waterdata_client/tests/test_transformers.py
+++ b/python/waterdata_client/tests/test_transformers.py
@@ -152,7 +152,7 @@ def test_optimize_dataframe_custom_strategies():
     # Custom optimizer
     optimized_df = optimize_dataframe(
         df,
-        optimizations={
+        transformations={
             HydroToolsColumn.VALUE: pd.to_numeric
         }
         )


### PR DESCRIPTION
This re-implements an important features of the legacy `nwis-client` package: dataframe optimization. This PR implements best-practices for creating more efficient pandas and geopandas dataframes. The optimizations are implemented as special transformers in the previously merged `transformers.py` module. The example below demonstrates a 72.6% decrease in memory usage after optimization.

## Changes

- `constants.py.j2` Added new columns to canonical list.
- `constants.py` Regenerated from updated template.
- `transformers.py` New optimizing transformer methods.  

## Testing

1. Added 4 new tests to `test_transformers.py` that check for correct datatypes and that the functions only transform the columns we expect them to. Includes testing custom optimizer functions.

## Efficiency gains

### Example code
```python
from hydrotools.waterdata_client import ContinuousClient
from hydrotools.waterdata_client.transformers import to_dataframe, to_optimized_dataframe

# Unoptimized client
client = ContinuousClient(transformer=to_dataframe)
observations = client.get(
    monitoring_location_id="USGS-02146470",
    datetime="2018-02-01T00:00:00Z/2018-03-01T00:00:00Z"
    )
print(observations.info(memory_usage="deep"))

# Optimized client
client = ContinuousClient(transformer=to_optimized_dataframe)
observations = client.get(
    monitoring_location_id="USGS-02146470",
    datetime="2018-02-01T00:00:00Z/2018-03-01T00:00:00Z"
    )
print(observations.info(memory_usage="deep"))
```

### Output
```console
<class 'pandas.DataFrame'>
RangeIndex: 200 entries, 0 to 199
Data columns (total 14 columns):
 #   Column            Non-Null Count  Dtype 
---  ------            --------------  ----- 
 0   type              200 non-null    str   
 1   id                200 non-null    str   
 2   geometry          0 non-null      object
 3   geo_feature_id    200 non-null    str   
 4   time_series_id    200 non-null    str   
 5   usgs_site_code    200 non-null    str   
 6   parameter_code    200 non-null    str   
 7   statistic_id      200 non-null    str   
 8   value_time        200 non-null    str   
 9   value             200 non-null    str   
 10  measurement_unit  200 non-null    str   
 11  approval_status   200 non-null    str   
 12  qualifiers        0 non-null      object
 13  last_modified     200 non-null    str   
dtypes: object(2), str(12)
memory usage: 165.2 KB
None
<class 'pandas.DataFrame'>
RangeIndex: 200 entries, 0 to 199
Data columns (total 14 columns):
 #   Column            Non-Null Count  Dtype        
---  ------            --------------  -----        
 0   type              200 non-null    category     
 1   id                200 non-null    category     
 2   geometry          0 non-null      object       
 3   geo_feature_id    200 non-null    category     
 4   time_series_id    200 non-null    category     
 5   usgs_site_code    200 non-null    category     
 6   parameter_code    200 non-null    category     
 7   statistic_id      200 non-null    category     
 8   value_time        200 non-null    datetime64[s]
 9   value             200 non-null    float32      
 10  measurement_unit  200 non-null    category     
 11  approval_status   200 non-null    category     
 12  qualifiers        0 non-null      category     
 13  last_modified     200 non-null    datetime64[s]
dtypes: category(10), datetime64[s](2), float32(1), object(1)
memory usage: 45.3 KB
None
```

## Checklist

- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) 