### PR TITLE
Fix optimization with list-valued qualifiers

### DIFF
--- a/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
+++ b/python/waterdata_client/src/hydrotools/waterdata_client/transformers.py
@@ -164,7 +164,9 @@ SERIES_TRANSFORMERS: dict[HydroToolsColumn, SeriesTransformer] = {
     HydroToolsColumn.STATISTIC_ID: categorize_series,
     HydroToolsColumn.MEASUREMENT_UNIT: categorize_series,
     HydroToolsColumn.VARIABLE_NAME: categorize_series,
-    HydroToolsColumn.QUALIFIERS: categorize_series,
+    # Qualifiers can contain list values (for example ["P", "Ice"]), which
+    # cannot be categorized because lists are unhashable. Leave this column as
+    # object dtype until list-valued response fields get a dedicated strategy.
     HydroToolsColumn.CONFIGURATION: categorize_series,
     HydroToolsColumn.APPROVAL_STATUS: categorize_series,
     HydroToolsColumn.ID: categorize_series,

--- a/python/waterdata_client/tests/test_transformers.py
+++ b/python/waterdata_client/tests/test_transformers.py
@@ -137,6 +137,27 @@ def test_to_optimized_dataframe_integration(mock_geojson_response):
     assert df[HydroToolsColumn.VALUE].dtype == np.float32
     assert df[HydroToolsColumn.VALUE_TIME].dtype == "datetime64[s]"
 
+
+def test_optimize_dataframe_skips_list_qualifiers():
+    """Verify list-valued qualifiers do not break dataframe optimization."""
+    df = pd.DataFrame({
+        HydroToolsColumn.QUALIFIERS: [["P", "Ice"], ["ESTIMATED"]],
+        HydroToolsColumn.USGS_SITE_CODE: ["USGS-01", "USGS-01"],
+    })
+
+    optimized_df = optimize_dataframe(df)
+
+    assert optimized_df[HydroToolsColumn.QUALIFIERS].tolist() == [
+        ["P", "Ice"],
+        ["ESTIMATED"],
+    ]
+    assert optimized_df[HydroToolsColumn.QUALIFIERS].dtype == object
+    assert isinstance(
+        optimized_df[HydroToolsColumn.USGS_SITE_CODE].dtype,
+        pd.CategoricalDtype,
+    )
+
+
 def test_optimize_dataframe_custom_strategies():
     """Verify that custom optimization dictionaries can be injected."""
     df = pd.DataFrame({


### PR DESCRIPTION
Fixes #310 by leaving `qualifiers` out of the default dataframe optimization map for now. The issue notes that this field can contain list values, and pandas categoricals require hashable values, so categorizing it can raise `TypeError: unhashable type: 'list'`.

## Additions
- Regression coverage for optimizing a dataframe whose `qualifiers` column contains lists.

## Removals
- Default categorical optimization for the `qualifiers` column.

## Changes
- Keep `qualifiers` as object dtype until list-valued response fields get a dedicated normalization strategy.

## Testing
1. `git diff --check`
2. `python3 -m py_compile python/waterdata_client/src/hydrotools/waterdata_client/transformers.py python/waterdata_client/tests/test_transformers.py`

## Notes
- I could not run `pytest` in this runtime because `pytest` and the dataframe dependencies are not installed here (`No module named pytest`, `No module named pandas`).

## Todos
- None.

## Checklist
- [x] PR has an informative and human-readable title
- [x] PR is well outlined and documented. See [#12](https://github.com/jarq6c/evaluation_tools/pull/12) for an example
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code can be automatically merged (no conflicts)
- [x] Code follows project standards (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [ ] Passes all existing automated tests
- [x] Any _change_ in functionality is tested
- [x] New functions are documented (with a description, list of inputs, and expected output) using [numpy docstring](https://numpydoc.readthedocs.io/en/latest/format.html) formatting
- [x] Placeholder code is flagged / future todos are captured in comments
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:
